### PR TITLE
feat: Add REST API endpoints for certificate management enhancements (#24)

### DIFF
--- a/manager/api/api-spec.yaml
+++ b/manager/api/api-spec.yaml
@@ -87,6 +87,44 @@ paths:
               schema:
                 $ref: '#/components/schemas/Status'
   /cs/{csId}/certificates:
+    get:
+      summary: Get installed certificates from the charge station
+      description: |
+        Queries the charge station for installed certificates. Uses OCPP GetInstalledCertificateIds
+        to retrieve certificate hash data for certificates currently installed on the charge station.
+      operationId: getInstalledCertificates
+      parameters:
+      - name: csId
+        in: path
+        description: The charge station identifier
+        schema:
+          type: string
+          maxLength: 28
+      - name: certificateType
+        in: query
+        description: Optional filter by certificate type
+        required: false
+        schema:
+          type: string
+          enum:
+          - V2GRootCertificate
+          - MORootCertificate
+          - CSMSRootCertificate
+          - V2GCertificateChain
+          - ManufacturerRootCertificate
+      responses:
+        '202':
+          description: Request accepted, will query charge station asynchronously
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OperationResponse'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
     post:
       summary: Install certificates on the charge station
       operationId: installChargeStationCertificates
@@ -106,6 +144,39 @@ paths:
       responses:
         '200':
           description: OK
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /cs/{csId}/certificate:
+    delete:
+      summary: Delete a certificate from the charge station
+      description: |
+        Requests the charge station to delete a specific certificate identified by its hash data.
+        Uses OCPP DeleteCertificate to remove the certificate from the charge station.
+      operationId: deleteChargeStationCertificate
+      parameters:
+      - name: csId
+        in: path
+        description: The charge station identifier
+        schema:
+          type: string
+          maxLength: 28
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CertificateHashDataRequest'
+      responses:
+        '202':
+          description: Request accepted, will delete certificate asynchronously
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OperationResponse'
         default:
           description: Unexpected error
           content:
@@ -1621,6 +1692,52 @@ components:
                 - Accepted
                 - Rejected
                 - Pending
+    CertificateHashDataRequest:
+      type: object
+      description: Certificate hash data for identifying a specific certificate
+      required:
+      - certificateHashData
+      properties:
+        certificateHashData:
+          type: object
+          required:
+          - hashAlgorithm
+          - issuerNameHash
+          - issuerKeyHash
+          - serialNumber
+          properties:
+            hashAlgorithm:
+              type: string
+              enum:
+              - SHA256
+              - SHA384
+              - SHA512
+              description: Algorithm used to generate the hash
+            issuerNameHash:
+              type: string
+              description: Hash of the issuer's distinguished name
+              maxLength: 128
+            issuerKeyHash:
+              type: string
+              description: Hash of the issuer's public key
+              maxLength: 128
+            serialNumber:
+              type: string
+              description: Certificate serial number
+              maxLength: 40
+    OperationResponse:
+      type: object
+      description: Response for asynchronous operations
+      properties:
+        operationId:
+          type: string
+          description: Unique identifier for tracking the operation status
+        status:
+          type: string
+          description: Initial operation status
+          enum:
+          - Pending
+          - Accepted
     ChargeStationTrigger:
       type: object
       description: Trigger a charge station action

--- a/manager/api/api.gen.go
+++ b/manager/api/api.gen.go
@@ -19,6 +19,13 @@ import (
 	"github.com/oapi-codegen/runtime"
 )
 
+// Defines values for CertificateHashDataRequestCertificateHashDataHashAlgorithm.
+const (
+	SHA256 CertificateHashDataRequestCertificateHashDataHashAlgorithm = "SHA256"
+	SHA384 CertificateHashDataRequestCertificateHashDataHashAlgorithm = "SHA384"
+	SHA512 CertificateHashDataRequestCertificateHashDataHashAlgorithm = "SHA512"
+)
+
 // Defines values for ChangeAvailabilityRequestType.
 const (
 	Inoperative ChangeAvailabilityRequestType = "Inoperative"
@@ -251,6 +258,12 @@ const (
 	MessageStateEnumUnavailable MessageStateEnum = "Unavailable"
 )
 
+// Defines values for OperationResponseStatus.
+const (
+	OperationResponseStatusAccepted OperationResponseStatus = "Accepted"
+	OperationResponseStatusPending  OperationResponseStatus = "Pending"
+)
+
 // Defines values for RegistrationStatus.
 const (
 	PENDING    RegistrationStatus = "PENDING"
@@ -298,12 +311,12 @@ const (
 
 // Defines values for VariablesChangeResponseResultsAttributeStatus.
 const (
-	VariablesChangeResponseResultsAttributeStatusAccepted                  VariablesChangeResponseResultsAttributeStatus = "Accepted"
-	VariablesChangeResponseResultsAttributeStatusNotSupportedAttributeType VariablesChangeResponseResultsAttributeStatus = "NotSupportedAttributeType"
-	VariablesChangeResponseResultsAttributeStatusRebootRequired            VariablesChangeResponseResultsAttributeStatus = "RebootRequired"
-	VariablesChangeResponseResultsAttributeStatusRejected                  VariablesChangeResponseResultsAttributeStatus = "Rejected"
-	VariablesChangeResponseResultsAttributeStatusUnknownComponent          VariablesChangeResponseResultsAttributeStatus = "UnknownComponent"
-	VariablesChangeResponseResultsAttributeStatusUnknownVariable           VariablesChangeResponseResultsAttributeStatus = "UnknownVariable"
+	Accepted                  VariablesChangeResponseResultsAttributeStatus = "Accepted"
+	NotSupportedAttributeType VariablesChangeResponseResultsAttributeStatus = "NotSupportedAttributeType"
+	RebootRequired            VariablesChangeResponseResultsAttributeStatus = "RebootRequired"
+	Rejected                  VariablesChangeResponseResultsAttributeStatus = "Rejected"
+	UnknownComponent          VariablesChangeResponseResultsAttributeStatus = "UnknownComponent"
+	UnknownVariable           VariablesChangeResponseResultsAttributeStatus = "UnknownVariable"
 )
 
 // Defines values for VariablesResponseVariablesVariableAttributeMutability.
@@ -311,6 +324,15 @@ const (
 	ReadOnly  VariablesResponseVariablesVariableAttributeMutability = "ReadOnly"
 	ReadWrite VariablesResponseVariablesVariableAttributeMutability = "ReadWrite"
 	WriteOnly VariablesResponseVariablesVariableAttributeMutability = "WriteOnly"
+)
+
+// Defines values for GetInstalledCertificatesParamsCertificateType.
+const (
+	CSMSRootCertificate         GetInstalledCertificatesParamsCertificateType = "CSMSRootCertificate"
+	MORootCertificate           GetInstalledCertificatesParamsCertificateType = "MORootCertificate"
+	ManufacturerRootCertificate GetInstalledCertificatesParamsCertificateType = "ManufacturerRootCertificate"
+	V2GCertificateChain         GetInstalledCertificatesParamsCertificateType = "V2GCertificateChain"
+	V2GRootCertificate          GetInstalledCertificatesParamsCertificateType = "V2GRootCertificate"
 )
 
 // Defines values for GetChargingProfilesParamsChargingProfilePurpose.
@@ -345,6 +367,26 @@ type Certificate struct {
 	// Certificate The PEM encoded certificate with newlines replaced by `\n`
 	Certificate string `json:"certificate"`
 }
+
+// CertificateHashDataRequest Certificate hash data for identifying a specific certificate
+type CertificateHashDataRequest struct {
+	CertificateHashData struct {
+		// HashAlgorithm Algorithm used to generate the hash
+		HashAlgorithm CertificateHashDataRequestCertificateHashDataHashAlgorithm `json:"hashAlgorithm"`
+
+		// IssuerKeyHash Hash of the issuer's public key
+		IssuerKeyHash string `json:"issuerKeyHash"`
+
+		// IssuerNameHash Hash of the issuer's distinguished name
+		IssuerNameHash string `json:"issuerNameHash"`
+
+		// SerialNumber Certificate serial number
+		SerialNumber string `json:"serialNumber"`
+	} `json:"certificateHashData"`
+}
+
+// CertificateHashDataRequestCertificateHashDataHashAlgorithm Algorithm used to generate the hash
+type CertificateHashDataRequestCertificateHashDataHashAlgorithm string
 
 // ChangeAvailabilityRequest Request to change charge station or connector availability
 type ChangeAvailabilityRequest struct {
@@ -868,6 +910,18 @@ type MeterValuesSampledValue struct {
 	Value string `json:"value"`
 }
 
+// OperationResponse Response for asynchronous operations
+type OperationResponse struct {
+	// OperationId Unique identifier for tracking the operation status
+	OperationId *string `json:"operationId,omitempty"`
+
+	// Status Initial operation status
+	Status *OperationResponseStatus `json:"status,omitempty"`
+}
+
+// OperationResponseStatus Initial operation status
+type OperationResponseStatus string
+
 // Registration Defines the initial connection details for the OCPI registration process
 type Registration struct {
 	// Status The status of the registration request. If the request is marked as `REGISTERED` then the token will be allowed to
@@ -1130,6 +1184,15 @@ type VariablesResponse struct {
 // VariablesResponseVariablesVariableAttributeMutability Whether the variable can be changed
 type VariablesResponseVariablesVariableAttributeMutability string
 
+// GetInstalledCertificatesParams defines parameters for GetInstalledCertificates.
+type GetInstalledCertificatesParams struct {
+	// CertificateType Optional filter by certificate type
+	CertificateType *GetInstalledCertificatesParamsCertificateType `form:"certificateType,omitempty" json:"certificateType,omitempty"`
+}
+
+// GetInstalledCertificatesParamsCertificateType defines parameters for GetInstalledCertificates.
+type GetInstalledCertificatesParamsCertificateType string
+
 // GetChargingProfilesParams defines parameters for GetChargingProfiles.
 type GetChargingProfilesParams struct {
 	ConnectorId            *int                                             `form:"connectorId,omitempty" json:"connectorId,omitempty"`
@@ -1235,6 +1298,9 @@ type RegisterChargeStationJSONRequestBody = ChargeStationAuth
 // ChangeAvailabilityJSONRequestBody defines body for ChangeAvailability for application/json ContentType.
 type ChangeAvailabilityJSONRequestBody = ChangeAvailabilityRequest
 
+// DeleteChargeStationCertificateJSONRequestBody defines body for DeleteChargeStationCertificate for application/json ContentType.
+type DeleteChargeStationCertificateJSONRequestBody = CertificateHashDataRequest
+
 // InstallChargeStationCertificatesJSONRequestBody defines body for InstallChargeStationCertificates for application/json ContentType.
 type InstallChargeStationCertificatesJSONRequestBody = ChargeStationInstallCertificates
 
@@ -1312,6 +1378,12 @@ type ServerInterface interface {
 	// Clear authorization cache on charge station
 	// (POST /cs/{csId}/cache/clear)
 	ClearAuthorizationCache(w http.ResponseWriter, r *http.Request, csId string)
+	// Delete a certificate from the charge station
+	// (DELETE /cs/{csId}/certificate)
+	DeleteChargeStationCertificate(w http.ResponseWriter, r *http.Request, csId string)
+	// Get installed certificates from the charge station
+	// (GET /cs/{csId}/certificates)
+	GetInstalledCertificates(w http.ResponseWriter, r *http.Request, csId string, params GetInstalledCertificatesParams)
 	// Install certificates on the charge station
 	// (POST /cs/{csId}/certificates)
 	InstallChargeStationCertificates(w http.ResponseWriter, r *http.Request, csId string)
@@ -1462,6 +1534,18 @@ func (_ Unimplemented) ChangeAvailability(w http.ResponseWriter, r *http.Request
 // Clear authorization cache on charge station
 // (POST /cs/{csId}/cache/clear)
 func (_ Unimplemented) ClearAuthorizationCache(w http.ResponseWriter, r *http.Request, csId string) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Delete a certificate from the charge station
+// (DELETE /cs/{csId}/certificate)
+func (_ Unimplemented) DeleteChargeStationCertificate(w http.ResponseWriter, r *http.Request, csId string) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Get installed certificates from the charge station
+// (GET /cs/{csId}/certificates)
+func (_ Unimplemented) GetInstalledCertificates(w http.ResponseWriter, r *http.Request, csId string, params GetInstalledCertificatesParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -1838,6 +1922,67 @@ func (siw *ServerInterfaceWrapper) ClearAuthorizationCache(w http.ResponseWriter
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.ClearAuthorizationCache(w, r, csId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// DeleteChargeStationCertificate operation middleware
+func (siw *ServerInterfaceWrapper) DeleteChargeStationCertificate(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "csId" -------------
+	var csId string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "csId", chi.URLParam(r, "csId"), &csId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: false})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "csId", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteChargeStationCertificate(w, r, csId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetInstalledCertificates operation middleware
+func (siw *ServerInterfaceWrapper) GetInstalledCertificates(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "csId" -------------
+	var csId string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "csId", chi.URLParam(r, "csId"), &csId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: false})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "csId", Err: err})
+		return
+	}
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetInstalledCertificatesParams
+
+	// ------------- Optional query parameter "certificateType" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "certificateType", r.URL.Query(), &params.CertificateType)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "certificateType", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetInstalledCertificates(w, r, csId, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -3082,6 +3227,12 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Post(options.BaseURL+"/cs/{csId}/cache/clear", wrapper.ClearAuthorizationCache)
 	})
 	r.Group(func(r chi.Router) {
+		r.Delete(options.BaseURL+"/cs/{csId}/certificate", wrapper.DeleteChargeStationCertificate)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/cs/{csId}/certificates", wrapper.GetInstalledCertificates)
+	})
+	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/cs/{csId}/certificates", wrapper.InstallChargeStationCertificates)
 	})
 	r.Group(func(r chi.Router) {
@@ -3193,173 +3344,182 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+y9e2/burIo/lUI/X7ATg6UZ9cq9gqwca6bpK1PnQdsp8W5O0VKS7TNE5nUIqmkPkW/",
-	"+wVfEiVRj7xW067808YSRQ6HM8PhzHDmWxDRVUoJIoIHB98CHi3RCqo/DxETeI4jKJD8GSMeMZwKTElw",
-	"EAxAlGBEBIicVmGQMprKB0j1ELX1MF0icH58AhCJaIxityNwi8USEHSbYII4YChNYIRiMFuDL5eX5EsQ",
-	"BmKdouAg4IJhsgi+fw8Dhv7MMENxcPDv0sCf88Z09j8oEsH3MDhcQrJAgxuIEzjDCRbrMfozQ1zUwTQv",
-	"gKAgUl/J/9gCAS6gbAIoAxElBEWCMgCdLuvosM2GsR5nDrNEBAe7YWXMw7y/4RHY2AX/AogIzPIxQ3CZ",
-	"7e6+QvINT1Ekp1oAsRmEwQoTvMpWqm8ze0wEWiAmp49uOLIwuOMef5wcyyHnlIGzw/NzsL+9u70HNqhq",
-	"AJPunvWT2lJLhIkSctRUJMUgIjv7d3CWIgYFvpHPhoTmvz53rbV627DIbIEmGmWDTCzrgBlEy2WMkYA4",
-	"4WrusLLGtZWcQY5e/zZ5P9j//fU55PyWsthP4bqlJfIQTN4PtvZ/fw2WkC8BnQOxrBFUajsMgxX8OkJk",
-	"IUF//VsNEWGAyQ1McHzBESNwhQZJQm+RB5LhHHCkaFiwDMlBCYAEmM9BZr4HtzhJAKECpAzdSO72gGfo",
-	"TEKQQzSjNEGQSJA4ijKGxfqc0TlOGvjeNgKpbiUhyzhSyK8PeQD+A3zZ/QK2QEbUlygGgkHCU8qElhUz",
-	"yHEEYCaWsu2ebDsdTXzv9kvv6kLskgR1wq6QXHWOndQ3JFzAJHEkKm9CjJBU4cDDJW6w/h5Q4kHPNpBf",
-	"lj5R6ziT3RFxSeSy19cR8jWJlowSmvFkvX1J2sS3+o0FWt0L7h+4MYSBnG/WBLZ6FwIjihXM54jEmrit",
-	"aBpEEUoFkgw5RnJ91Z+23WfPmFYM2h4+7r8LwuDkTP7zNgiDw8nJpKdkCzs3M/MAMgbXbTsh76bTCRKS",
-	"sRW2YBxjLfbPS2tXx+I1WgPMFY0pKWLEGtedbYO35e0kb8eXNEtisIQ3SiSBOZXyC5MFSKEQiJGDS6I2",
-	"uijXUfS+t6Of3kCG4SxB+qFhA9tSDxEpKRclWYykwLMbmdNMkSiJDEiQxEDujgDHl4SjFDIoNH1xtMJb",
-	"EU0o4XokO3r7QHmr+jhQCIZnmRQ5clVA+3Ar+FXuuyBR+0GxRe9tv5bI/313VzE4jARiXHOzs3vs7e7u",
-	"eui0vJZ29Zv2wHbamTK8kMKyTiL6Ra1HACPv5lpTk9zOzooVLHSkbTA2JK9A53SFwApxDhcISKA52Jgo",
-	"Tj+lhhmUEnWCBGIfYZIh3kOzKaZnufoNpcLtMQiD+jDyIV6Qj/vvDkuasnyo8IfJwmDQ04CuZpiguPzG",
-	"gTsIgyMMF4RygSPuHf0tZqtbyJD35XsEmZghKIIwUK/WYyR31fznCSVYUEkv+YvzbJZgvmztd0QXnufd",
-	"Es8guVFQYbJwFIsK3ZQbaOqZU7aCQi/lq/3At7KV7z5gErurPJhxmmQK8WOUWBV1LFUA1iT/K12eZyyl",
-	"vLQjTL/aeYTB9OuR3n+KR5qzzikm4gR+resZ9aEm0RLFmcbL/8/QPDgI/r+d4my3Yw52O4fV9moJ5GQQ",
-	"idbVyR9BnMiDzCeErpO1FwAuYHQ9Qjco8eK7i6sg4VoO9F4vpbO+ZXRVah9DgbYEXiGfDqA+mdK+H1T3",
-	"0BphlWbduNx+0vIsWQ9yH2F9OC2TvFGfy9pZn9U3vX7CYpkfNjt1iXy0HvCWe5bqRJKczYODf98JvuB7",
-	"+K19d+ikl+paOp/Xp/HZmYjLUH5BM4YCXRAsXIb5FITBoBejniOGaXznlat8/l1x2FD3sFddwDCIM6Zl",
-	"bz/eWuF8Uxob5bxgGJrNEodbSLaa6a+4gEy4+HoAk+VIbcRYG/XVkVteugSv9Hr1mJX+63wJuf62WbTt",
-	"+VCpkFLAcSfBWD1vOl2FZg5eLEiy4Vigbtp9yHZxVxYMlVVRfj2RE7kvgTijVnvsK1MpmeOF4QhtA3Ts",
-	"fv0OPKU+5NFn60ZqYiCFmPHCShh0atsew2Kpa9UtBxtWy5cqKvoKV6letFxzGxKB2A1MgoPg9e5uST2c",
-	"qNZOg739XUfKdyCGp5Rw5LOI6jdgzugK6NZlrJRgLtMfQ1wetOu9niO2JQ+SBhe2XVhIx3JH12jdY3HU",
-	"aesuVoGxGje3zJX6y1e23TAwRjNKhT2RaE16kqVSe0Zxtw4sJ5bDd+fzvsVbJ/k3r28Ziay02u+Q6L3U",
-	"JeR98C2XVGqU2aiNp56MBBiCMSWJp49PSySWSJsijXFDNt5SrX1GTwWuBxalVQvNyn6a0qvdhyJycLtp",
-	"Igwyck3obTvWmRZAKJZAcCCWUADIEDDfunhvMHA12ZyqC99AjIVyWF5XuzkUWtXk7PDD8VSeiwZvRsde",
-	"9QrHXkBX8OsVXKWIwQXqqwPBr1c3NBH9v0jpLWJXVaPf4PBq7+r8/WByLHXCw6tX+Y+jw6aTFIkhKx3A",
-	"Dt8Pjo6V4fDw/eDsv4by67OT48l0eHg1cH+8cX8cuj+O3B/H7o+37o937o/37o/SoP/l/vjg/hgFYfDu",
-	"zfRqcGj+OJJ/DI8Pr17vvtr942r/imOySNDV3uvKc7FkqPGxwnn98evf7OP9vT9eX033Kj+vDs9O3pyV",
-	"H+5XfvravBpUfstJnB6fDK5+v9rftX+/vnrl/P17/vfervNib9d985v75jf95nxwOj17Nx6cv796czad",
-	"np1cXZyXH0/Pzq+Ozj6dBmEwPZ6MBlfj/K9JEAYXpx9O5dvOXcVQseKTCleUKb5EzQ5N+nj4CAo4lSf4",
-	"OWJ9HKgckRjcIBJTtpX7LWMooFGC2lxuspnHDc1mWDDI1kDPW/e2oWcLYjTHRNtT9aibvn3AWApbrY3W",
-	"mohjRASeY8RyX5WG32ChbHX93Wdz1ZD4Rvuo3rhjbFSQtVnuf//337vWPR+te/366Xul6do9pOdq5T2p",
-	"TlR3HseUb9K99TdtdbR7bXVt2hW3C73xneT0kD/6WMeig+86XguTbB+2yNKEwhjExVcaNx0ckdAoP9qX",
-	"+74YD8HtEjFU6tO4W2bIDKjmnO9uGcMV4t3b9ypNgnnPRafqtKz1CtUE4Lmd2RzihOvezYF5t8swKDtZ",
-	"FyeXmkPbvAGYAI4iSmIOZkjcIkTU+GsAhUCrVJ0g2kdSh+upPIE2s79qA+QxVbG9i9WIJokJIUjtCb2f",
-	"UZILmnaMK+Xlo45akQ45CX1up+JJA7dZBdcFzay5YdAq0c5xgk6hb9KnjuuwxAo4QWCGpHB36LaGzQRy",
-	"cZHGfo8yXiEu4Cq1/cvGBkKQ6Y/6r9r9UWHFzzBWFqeLYjr6z7cQJ85Pv3ehbhtqOigeYZ4mcG3kWV3P",
-	"RiQ+ggL5afDTEulgA7v1GfEhqdYsR6z7R3E5QqgfHrFnA7wg+M8MeTbbTiZeFXNss2YZVBxSIhBROEoZ",
-	"pgyLdc8vz03zY7mSVnjcB4lSnjwCFnUUVT/YJRMjC3jN8VKRQCRZS2Bvc8jjTOlXYok5cD6uBIcV28er",
-	"112UqzTRHP/FGvpI+fiG+4yZ9gx5BwdIs7dDx8VdacIkWZLAWYKCA8Ey5MF81kzAybogXR0WoQLrbrFY",
-	"Yk0Oh+dnHKQJFHKVwQYk8SXh2UxHvVGWv+Kb250yPMNxYS8KXZz4EFn22jaLsblpZ6UknXdHxWknoviI",
-	"GPeqJaZviR4dF4TiYpwb89UPFO2pjuhphN+8sHxLb4mW3zvFdDaU0iNHkZpJyuiCIc4377OR5Jgx/TXt",
-	"Ikc5HM6PfCexD3REk4lDU8uXNzEPSy36GCpbdh5LZXrV+unAapKVo4DFwb10XxVSZJEYQbluzqKBjffT",
-	"6fmO/Gey83Z6vvnkyrAdW6vDYMMEnR2A3c2768YY3aAjL0cUSqtxhRgVUp6/tRrr4sUCtQ2GcxP5SW+w",
-	"ClXN4VWfcYBXKxRjKJAygvZjqUdT42voatfp8YJAkTEPet6UAnJB3tLKjxwzKpIILwiKDXFyLxfjBcFk",
-	"0Ror3xTMmHG5NlSNUhr7YXr7O0RHDntUGAcKLLIYeY2lCSWLprdVCGw/7lc+aIbxFC6GZE49xptMLCnD",
-	"/6t5HRNNUorvKQOQgOEREHBRY370NcVs7af+IxUlatUu3QFQH6j181Jt516fQimR1Uw8q6te2qEk5AtG",
-	"s1QFHOezq9htdnsM2rQ/lLFW2xUc08abhEbX6q9jhQAt7FUsTKAM8GbDnn59kLCXxJaUoDomgnkcDxNl",
-	"/gVIvgVGE5KUnJRxBRLssShhP/any+o5oYxmz7nDocc2TbEg3LriOlVUWXTVDy0jzEUPM1tEiYCYaG1b",
-	"R7QmSNwBVfJhoxKjgmStX8ooNCTfrjqWpIcvJPFO22e5ZXCt1MrSQJI4MCo5/doWqYn2ulxULooaYW5c",
-	"1VHx9d3XU6NXAuDovM9mAVvw1IQOvx42qOpy+Z5VnS2MY6kke3ekyBzN6y8oZTEm9mpCG424+6H6MrPi",
-	"ydOrencl92pvA3lC7H/YVKfW742yPj93EmMQ67MRXWOyqLsaR2en765OzqZn40+D/1YepPGH4em7q3eD",
-	"8eDdsfNgdDYNwuDs9OpoPPx4rBufnV5NpuNj5WC9OD06Hr8bn12cHtmPP/fbIcX6qsEHm1J5psiR2tFZ",
-	"hQItdRhaKNavslplknAg8pPt4g6G+YQuvBZ5E/ygbjVseo4oC6/6hbjID60t2rtuqVR3fb6VmkVCF46E",
-	"7KeC0yTuOaRu+QhDMrSiAo16nNEUah/BMVGLgikB4COBhC6m/suK61QdBuTEBQX2sOWoWI5hfESlIjAx",
-	"98Hkr89efCiSGjabPE0LpUVSIBiMrrWpTUJRONmazoK/jj+mdtDRq+TiUK1dE1t32bUkPts9FH+VtamF",
-	"KMYFNUDOaYTVrSB1900RRQ6515t15/l73RLaHOR1UWTqhPoGxtazUA5xMzd51U5/jtgKc6k+HCGCH2hV",
-	"qljvfeZg+6KuMlk7tmkEKAMX42EfK08RjtTDyP5WNbZW9gSSRWb8EpUgLPMGyM0LbKDtxXYI/oHIP+S/",
-	"XP4bo39UTOr/VKyTn256BMwqdOQzaMGpA3YN1JMK5nRvB5fkP8CXweRwOPwCtsB5AuWJDn0V6vn76clI",
-	"Ph7jaKmemq8EJgvV4GKsPrsYj6TAMz4QsIFXcIFCcItmKVygTXWNLVdy5FhBGMi+JT2Oh15h6/PU1M0E",
-	"ZkBLFdYNoWd1KmFNDtdRgtQkqMjvnlIVGGg+46r1kLxllAjZcrKkt2CG5pQh3ZJLgcio1hc0xpJbuOb5",
-	"F/onuMEczxIUgiVeLCXrW4BKGHDgUkd51UsQBk6fbSgpHEB18WDCp/W1fG1AqfisZqhwVWk02Y/kPI60",
-	"ewhGAt8YM67qDinmV83fwiwRKJatlV/MalFLyAEkADFGmUZorPGuWpmkAQkCs0woCyUmIONIUxHJX+cf",
-	"0ExFN3LEbnCESvizAAdhYICRaDRSr+iqAYc2qtp31jH3n1eykY3chgLAIj1DrlXd7b5jKRWEDTliyMrn",
-	"h+Z28O8hKmw8bpqsPbibZma6fU/szuXFiTuOxx0nmnXW2kasMV8gpt8e3OEFnTp+zuGRcu7IY4V2hjnf",
-	"bnYabN3VL6HXL5NzFDWbF87hQp11Ym1KqBCfx6RgLr5UZLu5VUwcbVEFkEutLWPEjbUouduLG6jNBOIA",
-	"BBiKKIvvQSU+wqDzOUeiXefVs+DXOE0bJiGo8KmyU/nYQcgKimgpZVkxhQ6ldVW6n6uHsdd2cuA7Fn7S",
-	"zoNAh9KWeVBKRljjBI+O9NV77FUfANPAqiQajm19+QhHIXB4YvsNWmDidW4WOlPFhargNOGZG2N4K/Ww",
-	"ifKyHEEBvX01+/rsAU8TG+QZQyupoWwcQrWZHn8MwZAkSITgLBPq/zc0XjdEgcrvIYmbT4SlITR6jgli",
-	"i/X2QG1728OV1IC3x2iBuUAsBOf0FrHyW+/g6RJ6eVw+tsPGYGO0F4LRfghGr0JwGoLR3pb8d1/9+2pL",
-	"P1Hv97dkk9GrrdGed7yM+ITBBcGiNs9PyxBcy39uIJN/6v8+yYch+DgIwbX85wYy/S4EgxB8DMGHEByi",
-	"hOOMh+AtXDJElgiLEJwjFiHix0LDLYoTO39N5BskWyGGIwC5CfrtFr83jbJWrxVrILAjFUCsYzgwwQIX",
-	"iQeqOYNkk7PD8yFgTo8gZTTS1qsyG3YnJbEbW6k7c2ZUzlr9Uh8UMQcryK5RLJHyZXz8bjiZHo+Pj77o",
-	"VD+yqaDXiOSJYaDOFAQEvSSzwhMJIwmtfAsQiVOKieAA3lAcW+s1QSbJQut82wG8JF/Oj0+Phqfv/PBR",
-	"kqzLQFrAZMMvOzRK8Y4xffMvoX2yv73/RSXWKH7vRAwp5xBM+JdLks9pu6QWGmCCMCgw50/rImH0L5oG",
-	"30ljFNHVKiMq8wFZ2LM7Auhkcg42DsfHR8en0+FgNLmann04Pr0aqEifrnxPGUv8w8tzlCEYNYLFTr6M",
-	"akWsb1/HIE1OJhrfMBJyWXTOFhIXjoS8F0t3dbtch9qjEObnO6mgt/iHiltKeUPuu01YvOxrlXeGztWr",
-	"HtfqioE65tMrlRxD8pwFnTQmzhB3OyLotDfOMUFZLWVnqJ/Lrs2fPpycgX++3t1zrMK5d92BuMvF7nfD",
-	"drlzFSPdLpUNoX5PQJ4bi6m6uOzhBm516ecWcd0KWIdvV6cOQlpsvbU7JOp6obv4D0lqUFrOMPdVl0Hr",
-	"pOAWp2a+5Gb3exix9qNQzS7xQNyfQG8hN1zXP0L/p2GMHKE5KfmD5O9F9T+OzLvN2VVdye3eExFTWH3O",
-	"oihLcf0GUGEECoNDSCKUJKUIms/dricXOWEf3mwxeUt+E86GUuY00erAkpCozSZFTKLaQcmEzuVR9H35",
-	"Yt9dE2xOkKjka2mEtCtlRLvzKeKVce6a56ZDYnr6b5hv+UpF43R7XkeoXNCo2xGaA+Kb/Fzvp9PzJs+W",
-	"srD6RYt65Uj0e2RRBO6LB3h5pn4le0AqES1at6xtPjBaohMTaVD1UcY2PeYSCpUYTgkOpbnL76Sijrk9",
-	"drgSZPRp8N+TIAwGo9HZp+Oj4q+rs7dvR8PTY3Wx9+Px2J/5hxLBYCRa9kP1XtkY0clgeLTp8fvZM8aG",
-	"9kPUMxma/IGUqXhzk0IxOAg2/j3Y+r9w638/f9v/vrmx9Z+bxYNX5Qe7W398/vZH/dnmfwZhY7DMoRfZ",
-	"el6qgXZxGRGNOc8knuUppaJRdXi3wkDFVfqRiDnAsQ685EoTzNKkWF2lJ67gNQLilgLKwIoyZF/dUnYt",
-	"jz+UoM4bLGEg4fclORyaecnlgGQdghXleRoRpSLU8mOapiBlUtTFNrnr+O3wCESQxaHydhAkT76Q4WSd",
-	"H+/8lyS0Q7F5OVKG5ogxFAPb1p5XbXAy5ECqNa9f/bG1VzQy4TV3WqrCid5A8yraX+/ZEWWxUs+UM117",
-	"0WOwgReEMo0Wrbft6Ff9L0epEKAmplMvJdF0Euar0mxftaR79ZgFXCHjSpSjq/dnh1cXk+OxFCbn5/bP",
-	"s+l79b+kAq8w8d47kkNlWu3SQgLHPWhZRwJ7SNnc8lI92XBhT9ITzDOYaJu7HyTdYochGOtMqartjtUM",
-	"I2szyukfkoL8eySEKuRPsdihTZur70U5sjdnXjvz0NktfDvRBUlodJ174PoqNxVsHjmJX4yWLtlO9f3Q",
-	"fHVhoJksj0q9w1WbO0Vfd0akEnRbjUbdWGVcgBkCC8W+8ggAiQ1d3XzkaGJfELEyHMbxTh6Y89CQ4q44",
-	"Tj1Qe1iZwf7G2yxJ/mUSWNv0/hLLITjC8zli2mr5L3v5y7qRzdQ2HVkie1J5YIvPupX6cgC0A7iPyD6a",
-	"JMa8ljOtJdWHKHIfl1KZNYRL2sbc5zQyr0zHzRmh8pTKDX4z7X7Ke/GoNIYcPJel22+gtvvuSzcU6lSO",
-	"m/z1rd/5Mk/YLNM+YKoZr30IIN6r+YelpNqdglk18tGRXeM6Hpvh/lhNoN0f7I9uhu77Ql2Tx5ZCnOmE",
-	"VcK7c9q2gvp78V+/VC0TJArWaWW+1qx8ORv3Tc2XI2PSK8lepf++aVoOnZWwaVqKBXEDEgcWHhNKWknQ",
-	"9/lugsDS2qPzwIM6viOZTp4gvWBOa830WZBjLa1gT0pt2Sasxyhvkp+cMfMEKVUF+Yvkf5H8DVDnAqRl",
-	"pJy1WolMzUS0Z5wsSkZwkH/hO4CtMmFLTfXr0FyC13LWNXCNEYzPdHLLTwwLZP6Wj9Vvr4xMpfrI/RHX",
-	"3uHNBxzAiFEuZYCUw/wuGTU/llTKoFc2ro5clV5BWV/5R93SvyuG1XdQ1fXASKe7XEGcBAfBCqIbtCUQ",
-	"XP0fsaTZYiluKbvm2xFdBZbkgxN4/BEB2aieW1hdxyAwAYPzoa7DI5CyMOa2RP314eRkEgL01bTW1ZDy",
-	"CzkZ1yEe2yp6LUJGpJvxB6k8PEs5rWM1RVJAperbhIG933gQ7G7v6nY0RQSmODgIXqlHylC5VNyxU6kK",
-	"lFLfGUNfQ1BGvlrtJmAqHcnhddUUFeQgyV7ORZTLJKnjYSaWUtDqyk8eJ3PGMVmAVSYymOiyUdbJJ39Q",
-	"e9WBq8ypOjEInc9Nigk5AJB/b81gIiUY04En+Wdy7zAzKpf4MAEXb2i8rtxsgGmaGMvJzv9wfRzXR9dO",
-	"n4gzwvcytcrjrHbsqU1ZLcf+7p5nPzAeVEVxpnzdI4FnVBIFWdWhiL6mSvvTfgrFajxbrSBb5/iTBFGa",
-	"YFgiqJ1vzo/3kC+/68klyJtFQD1vIrIlFCr4YIYQya+subRnqAZWqr+Vir9dEqP+Hh2PwWwtEPfRhgak",
-	"TBspZFAFeXJVTgFLgCUTFaKhMtWgutShsyTtIUffP9eo4jdP3C21l0MkYfymmzwxUZxSAeY0I8+LFvV6",
-	"VWkxDBa+cOURpddZ+uOJTMPxrIhs9+mkXkWgOTi37s+/OQ0XZFmTp3znW8SH8ffm7dnGPkvZSdCtt1Qh",
-	"X3OBVib2kPNsZci9vv1eEskChAqwRkKzgophlFoFilWwp+pFW1E92zcmag82mb307aZLwinAwmjDiOQZ",
-	"2VGsd3csVByknIJUUOX4ubfCxz92zqVyaHUe8jhIK8C6Zz4fx/G89EWNrfb/2cBWT6BH1Oqq/krahF1M",
-	"L/1W2GAHmqqyXvE+VjdotN/XRopbJIHZuhDkCyjQLVyri5CSXFaYILCkt30U1GZxXlulZ0KQTyXn/VTp",
-	"ueboFCDMxDK3RP11Yt9YK2u09ay4oKBdhwTdsM8qK7iVrxu3B23A1v3mVKsTLDdkmQSUeWpcb1+SC3Nn",
-	"QcBrBCRbperCSvn6pwo9XEF5/iWq+qb6eY2kjC9ulsIFxFKyG4sxBzMqlkV5TbnNFDZJ3w5Qryf+S4v/",
-	"htrpvbaBfY/z1pj5wVa5RHjub9BeRZ7NVlg8t/3i0FsUvsQNFU5RQQc7UYIga9Oj1KS5T6kRFKivARbc",
-	"68JXI2yDS6I9819F5b3FqNKd/swQWztmk/szgYSp5Dg/lHA8y32nnQoV/gyOnzn1KRg9qw8o6dBdqtW9",
-	"LR2WF9VWLnd311IZ87+Hmusr4N5L3O164uw/PCsSMlMr1273FpqvUZAJmt5Ki5K8RhMuE9G7WqA472di",
-	"0JTQbFeoWf9NN0qmOf3USgcawmpNRNTQV1Ot16LbR67x2wRJqQRtz0k9uQZeqVjrIce86JvNEZKXlX1R",
-	"wAuufIeEH0N+dWGCBLeqs/OFqeRe15/9DG61apX6eAVZAUKo3BhAuzHUb6kPxGsCVzgCKcPyoU8pqN8R",
-	"eRrOf6JNoPmKyyMou7XVsrrGnxnKtKLxwg+GHyYefujaj3a+pbZid8Xb41Fc/xIqDb3dpE5d8RYb+n02",
-	"q5eNr3Hj6+BNpVi/MGbPE0gna9rK1FvcKTzdqCzW6lj/OG3xcRkyL8fudpSv5avXu7vtZcW7mNOpnu7p",
-	"Pxg4MT9NleqfVkesrazPSmsb5SUsXjiuqhp6UFTlOKcIb5uPQmW3NXYmc6u6XKLYZ5TVvufcOFQtC719",
-	"Sext8mQN5jgRiIHZuqSIlosgex3T9tyYGx5Kc3oyy0MvP7bPEhF6widXcMtczHRStdWnX0k17ONxUxi8",
-	"XQV+Mr71lQ738q6vePgL//qOdgVhRk011dUtRhEtmz0p5U/NTRtKOlnWU7d/+5JYv8/+7j7ItSEVNJia",
-	"+vwmAnwbTOjKhpJysIJr69sE0AR2NjtKfiqmfirzojvt8r2q/kfLp4OkmcNdJblEe8Zdo/OkiRc1uYeb",
-	"qJnvy5t5DAXcyusYNzqNJipqpanANvQG4+hSzDohIyQx4GgFicARvySqPlhRQltnBJN9P8BJNNFFR/Oy",
-	"07+u/8BXHP0v5mxvfe92lvaW936mzi9JSxWA63Xkq5xU1G5o5qOhEWEcQF8937xwuWExFPsLg0hO3tZO",
-	"2Mp75Xg1NZxLI0gGMqOIJVrZeM88cZ/NheoPQ1OLVdpcnVIVf5+t1VN+/RGste4y5Wktn89eVwnf0fB1",
-	"lZRvZo6dIuFPZ3Bb1FX6Ok8Y2sQwfQ5/9XLkz5Sgn+gIVp+/hzqO3Hr/GvfP5wxWOwU110qvEaZKlLXl",
-	"5NVq04BgXrtA0FLdAr/bC/CIIaQizUbHR7a1Gw9mqzGE1tyiXGAqmnhrBjmK7UfaL7bKEoHTpFoyg29f",
-	"kkI7UmluG1xmlcRgv6yO1JhR7RHktSWB52W7B7b8Qp4shUr1ytxUf3Yut7hSJ6UzqqjCqTvfzB81F1x1",
-	"O1nRG6Vv5ccWO2SubVUQWbBpD55SXopnx1VhW6EiJ3+mDfjzj5pj+Km9YS+c9CAfWZWXeilkJW5qU8ec",
-	"cNHcypzX23duuFSg4E381WjCVwWCKMv3xH4M+K4q6flz5L+3epo5bmZrp5SRMEmk/B5pUXaF9ygVVpRj",
-	"6geJRXgDDM7rO4FRKpR1d9GwQOJFMDzEFeBnyHa5YAvF3+eUlhe4t6nF+h3RwkuCSZRkukhMuf5wmF+w",
-	"syjfwHMAyXozNBYNNVLK6IIh3svV99ZA+dRHvWdxtKtM1kNHtsXzO9Q9M27yU3cj/2R5oc9uS2C1a3OW",
-	"bLRpVIzkDC2yBLJLoqzsquRRtUuuTfI+Y2FMb4lOc0BinRAnSdTwtotLkm/kvayFOnGkl+d+3fOmnaGe",
-	"/CMeNqu0UTIMPhsGmTK8WCDmo+T2/UZdMtpKTOrN7q2GrlKVB6Epv+h9DYIjfzrQX3t38E+6zZ8zakL7",
-	"c9k2pIpGqCEPRVbPbR9pzIzbGIKvZQpvzavbuWdU76DOsyQBJkusut6qwu6dTK/5ztEo4p83zzy+jG/I",
-	"iPwIQj7H7kscsC8Lk9pKmvmmaUfZuSnySvc+xFRSTdtq7A2DXxIubC55r6Wjca8ZldIk//K7jDPd7v1F",
-	"CTS7EC87y0N3FovKOqcseoYqOLX9+4YoaKOdovbFZt+ggpGE6G8TTTCii0fcQ+Qa/SzRA1V66jojLO4V",
-	"NeCM8ojRAiO6eLZRAk3GXjdA3tKIqpDnM/eaBpUN5C+98Fvg2LtHLH6CCIQa8VWpWtHN1k1e6rzjFsUS",
-	"S00DSwnvlmMHG0gVilb5fLOV+i4EKb1FLAQ3NBFwgUKARLS9CS4JQ9pUbYMuG+1K2iujsgCSGKS6Inwz",
-	"g5yU6pI/V+fLbF0tEPmYNxubhhSlUv8NgzqN/HzXi8UFZEKVhAIbtojkZrNfiYmpLm9UDNan+lEbBIjE",
-	"PcdHJH6k0U/gV7kujsJuS/Triy8ZIw0w2Lr5nvtse+q6nO5Z/epxe66SgdEHDr/GKdgo2KkJO6aSvxe0",
-	"3fDHJWJw+LxNiz9xBZS9exQDnqla2/MsSdYvJ9zKflES6j2UIoZy13tL0FomJ4O4TjhYuhKg8mKadNwz",
-	"BNSsizSw9Xh+zAFWCTMvicp5ZnLG2hLvUB4TFnIvgklVvueJNVXCaxQtIcF8FQKsqrfb3i7JXGWP0EXt",
-	"8vs/eV7DOFP7kUBcYLLYBoO5UHHkpWmF3lSftja9vj0kKZGakvNVrESQmLRv8zmKBMBz5RJhmVo7Qf0H",
-	"mXwl/o55OidIyAX5ZbIWOcvZI1ORWxi4OTehykbK1f21on7znTOoNHnwZqhMpHnh8nJtuBsMdfSCLrWN",
-	"TumtN6BNATsu14z/exzIPaX2H+Fg7q55wwF99y8g+zcwtsO/bL5uCJ2id7fIf6nadzO/73wrVeRujULV",
-	"Bb85gARILf+mXMn9wQwfqe5rFeJzjtfDO+TtZfxqo5/BwDGtTLkLgGoR9WZIOmtI3iP5o6r63ioJfqx9",
-	"u0T4z4lHNX3DnpzZbE8ZqSpBbtM+NsE3a2BQYQ6U3MPFvDFC1TjVC+h+KsOhy13G7LZhsHFg0NBiZNB2",
-	"Ul/GGP2pkzamePA1VZMIA5gkf3UeGWehuvIMlijuZUt16jyYiBAHO3VeFc2pYeUaiI6z1DNO7afAf6gC",
-	"qTrJdwlo61UW6mLVW6cqT7sa3u/+dqYilzoCsIYTkBm0KoX0slXWUujQr+bVNLFhf8ezsZn6z3w0rqy2",
-	"ri6+levKzcteqXH+U3FwQ332+/Ky7u7HMnNeGb500vGk86nyd6kuaoeTqiiQqiyYbZmC8viAvDxr072g",
-	"fH0AJPEOZUXZR0k1fVy2+RA/l+YVVUuk+t1VRZnJe3mNbioVTX2DOPUrf0yWsHoFYI/0qtcAftHK2rOD",
-	"3fhLIzfnBlPZoKvV9ztygmlOn5Q5vT0dWD6CzQnWkv/5Z2DyJ9qmatXbf0guoKYa8u3pgKq131+Se7Um",
-	"p+7mWblr22s5O9/sX71L6tkPikK+qmhLS1G6kfmiD7/lvXdxWgF3cNcyj08RoBdZlejXK0PXvOialphp",
-	"14t8iCrnDFLIxLpCQeAI2Tuc1s5dcrnmd8ryqnW3OEkuCcKqzreVC8r4J8djFYj1mMaIZwFIEnALcXEb",
-	"SD9X9apNd5ekqcMuuj+XfQVPZTooIPpVqa6ZVjThCXqNSIcFV91RlO24DmQw9eczU7nNxkCjXDFpMMtO",
-	"VR8NZ9PuoJz7JOquRx25cUYdYUYP1bGxQCvetcgKKZ4q9I2GUL0Sz88EWQ6FL6Bs99JTZq8+Aag/uj+N",
-	"TZAmsScSF2alfiE5oWEyt6eVu7S+ho6Y2Pmm/rvAWs1pL4b9wLXU/djl7DZmWcj6Hhxevf5rPR0O8VS0",
-	"9DrKXypYlytYN9GlbKxscW2KcAJidIMSqsuK6vZBGGQsCQ6CpRDpwY6+xbakXBz88dve7g5M8c7NbvD9",
-	"8/f/FwAA//+04P/KV/EAAA==",
+	"H4sIAAAAAAAC/+x9+W/bvLLov0LoPeAkF8raBecLcHCfG6etb7M922lx30mR0hJt80YifUgqqU/R//2B",
+	"m0RJ1JLta9qvv7SxRJHD4cxwNg6/BRFNV5QgInhw8C3g0RKlUP15iJjAcxxBgeTPGPGI4ZXAlAQHwQBE",
+	"CUZEgMhpFQYrRlfyAVI9RG09TJcInB+dAEQiGqPY7QjcYrEEBN0mmCAOGFolMEIxmK3Bl8tL8iUIA7Fe",
+	"oeAg4IJhsgi+fw8Dhv6VYYbi4OCfpYE/543p7H9QJILvoTu195Avh1DAMfpXhriow+m0BUvIlyCGAoI5",
+	"ZQDHiAg8X2OyABDwFYpku74YsQPLx+VGcpRBsqAMi2XqQb19BTKOYiAoWCCCmIRPLDWMQRggkqUSFZP3",
+	"g/1Xr4NQ/vHi7y/1H6/29h28WCSGAeY8Q+wDWkvg6iPLp4DO1TC66d84WGWzBEfgGq2DMEjh12NEFmIZ",
+	"HOzt/71xhFOYojsMEWMuMFlkmC9RDAhMUZ+hOGIYJqdZOkOsfVl1S0B001LXL3e7aK28WrUZVpFagatO",
+	"nc2knFOMl6SXkCzQ4AbiBM5wgsW6kaLNC0k5kfpK/scWCHABZRNAGYgoISgSlAHodFmnZ9tsFOtx5jBL",
+	"RHCwG1bRnfc3GoKNXfAPIHmH5WOG4DLb3X2B5JuCk+xHm3JRMMGppOliRTARaIGYnD664cjC4I579HFy",
+	"JIeU/Hp2eH4O9rd3t/fABlUNYNLds35Sk14SYaKEHDUV5LDe2UpyJb6Rz0aE5r8+d5GUetuwyGyBJhpl",
+	"g0x4GMggWi5jjATECVdzh5U1rq3kDHL0+qWWFueQ81vKYr/Q1i2t3A7B5P1ga//Vay0cDetWCGplOyzx",
+	"1uuXPgFBbmCC4wuOmGT0QZLQW+SBZDQHHCkaFixTko8ASID5XIpG9T24xUkCCBVgxdCN3LA84Bk6kxDk",
+	"EM0oTRAkWpBEGcNifc7oHCcNW5ltBFa6lYQs40ghvz7kAfgP8GX3C9gCGVFfSkHOIOEryoTe/maQ4wjA",
+	"TCxl2z3Zdno88b3bL72r78uXJKgTdoXkqnPspL4R4QImiSNGeRNihKQKBx4ucYP194ASD3q2gfyy9Ila",
+	"x5nsjohLIpe9vo6Qr0m0ZJTQjCfr7UvStv+q31ig9F5w/0BdJwzkfLMmsNW7EBhRrGA+RyTWxG1F0yCK",
+	"0EogyZBjJNdX/Wnb+VQDKwZtDx/33wVhcHIm/3kbhMHh5GTSU7KFnfqZeQAZg+u2HZF30+kECcnYClsw",
+	"jrEW++eltatj8RqtAeaKxpQUMWKN6862wdvydpK340uaJTFYwhutjM2plF9SQVxBIRAjB5dEbXRRrnbr",
+	"fW9HP72BDMNZgvRDwwa2pR4iUlIuSrIYSYFnNzKnmSJREhmQIImB3B0Bji8JRysoNUVFXxyleCuiCSVc",
+	"j2RHbx8ob1UfBwrB8CyTIkeuCmgfLoVf5b4LErUfFFv03vZrifxXu7uKwWEkEOOam12lb3d310On5bW0",
+	"q9+0B7bTzpThxcKnPJoXtR4BjLyba01Ncjs7K1aw0JG2wdiQvAKd0xSBFHEOFwhIoDnYmChOP6WGGZQS",
+	"dYIEYh9hkiHeQ7Mppme5+g2lwu1Rmgu1YeRDvCAf998dlkwd+VDhD5OFwaCnAU1nmKC4/MaBOwiDIYYL",
+	"QrnAEfeO/haz9BYy5H35HkEmZgiKIAzUq/UYyV01/3lCCRZU0kv+4lzaMHzZ2u8xXXied0s8g+RGQYXJ",
+	"wlEsKnRTbqCpZ05ZCoVeyhf7gW9lK999wCR2V3kw4zTJFOLHKLEq6liqAKxJ/le6PM/YivLSjjD9aucR",
+	"BtOvQ73/FI80Z51TTMQJ/FrXM+pDTaIlijONl//N0Dw4CP7XTuGu2DG+ip3Danu1BHIyiETr6uSHECfS",
+	"kPmE0HWy9gLABYyuj9ENSrz47uIqSLiWA73XS+msbxlNS+1jKNCWwMrarcGoPpnSvh9U99AaYZVm3bjc",
+	"ftLyLFkPcj/G2jgtk7xRn8vaWZ/VN71+wmKZG5udukQ+Wg94yz1LdSJJzubBwT/vBF/wPfzWvjt00kt1",
+	"LZ3P69P47EzEZSi/oBlDgS4IFi7DfArCYNCLUc8RwzS+88pVPv+uOGyke9irLmAYxBnTsrcfb6U435TG",
+	"RjkvGIZms8ThFuMB0iKACRdfD2CyHKmNGGujvjpyy0uX4FSvV49Z6b/Ol5Drb5tF254PlQopBRx3EoxV",
+	"e9PpKjRz8GJBkg3HAnXT7kO2i7uyYKgc5fLriZzIfQnEGbXaY1+ZSskcLwxHaB+g4/frZ/CU+pCmz9aN",
+	"1MTACmLGCy9h0KltexyLpa5VtxxsWC1fqqjoK0xXetFyzW1EBGI3MAkOgte7uyX1cKJaOw329ncdKd+B",
+	"GL6ihCOfR1S/AXNGU6Bbl7FSgrlMfwxxaWjXez1HbEsakgYXtl1YSMdyR9do3WNxrP+7t1dgrMbNPXOl",
+	"/vKVbXcMjNGMUmEtEq1JT7KV1J5R3K0D69iAge/O9r7FWyf5N69vGYmstNrvkOi91CXkffAtl1RqlNuo",
+	"jaeejAQYgjEliaePT0sklki7Io1zQzbeUq19Tk8FrgcWpVULzcp+mtKr3YcicnC7aSIMMnJN6G071pkW",
+	"QCiWQHAgllAAyBAw37p4b3BwNfmcqgvfQIyFclheV7s5FFrV5Ozww9FU2kWDN8dH/mhc7AU0hV+vYLpC",
+	"DC5QXx0Ifr26oYno/8WK3iJ2VXX6DQ6v9q7O3w8mR1InPLx6kf8YHjZZUiSGrGSAHb4fDI+U4/Dw/eDs",
+	"v0by67OTo8l0dHg1cH+8cX8cuj+G7o8j98db98c798d790dp0P9yf3xwfxwHYfDuzfRqcGj+GMo/RkeH",
+	"V693X+z+cbV/xTFZJOhq73XluVgy1PhY4bz++PVL+3h/74/XV9O9ys+rw7OTN2flh/uVn742LwaV33IS",
+	"p0cng6tXV/u79u/XVy+cv1/lf+/tOi/2dt03L903L/Wb88Hp9OzdeHD+/urN2XR6dnJ1cV5+PD07vxqe",
+	"fToNwmB6NDkeXI3zvyZBGFycfjiVbzt3FUPFik8qXFGm+BI1OzTp4+EhFHAqLfg5Yn0CqByRGNwgElO2",
+	"lcctVYaAVoLaQm6xif5XwvtshgWDbA30vHVvG3q2IEZzTLQ/VY+66dsHjKew1dtovYkmiwEjlseqNPwG",
+	"C2Wv6yufz1VD4hvto3rjjrFRQdZmuf/9V6+61j0frXv9+ul7penaPaTnauU96awQ2Z0nMOWbdG/9TXsd",
+	"7V5bXZt2xe1Cb3wnOT3kjz7Wsejgu47XwiXbhy2yVUJhDOLiK42bDo5IaJSb9uW+L8YjcLtEDJX6NOGW",
+	"GTIDqjnnu1vGcIV49/a9SpNgXrtIp2hovUI1AXhuZzaHOOG6d2Mw73Y5BmUn68JyqQW0zRuACeAooiTm",
+	"YIbELUJEjb8GUAiUrpQF0T6SMq6n0gJtZn/VBkgzVbG9i9WIJolJIVhZC72fU5ILuuoYV8rLRx21Ih1y",
+	"EvrcTsWTBm6zCq4Lmllzw6BVop3jBJ1C36RPndBhiRVwgsAMSeHu0G0Nmwnk4mIV+yPKOEVcwHRl+5eN",
+	"DYQg0x/1X7X7o8KKn1GsPE4XxXT0n28hTpyf/uhC3TfUZCgOMV8lcG3kWV3PRiQeQoH8NPhpiXSygd36",
+	"jPiQVGuWI9b9o7icIdQPj9izAV4Q/K8MeTbbTiZOizm2ebMMKg4pEYgoHK0YpgyLdc8vz03zI7mSVnjc",
+	"B4lSnjwCFnUWVT/YJRMjC3gt8FKRQCRZS2Bvc8jjTOlXYok5cD6uJIcV28eL112UqzTRHP/FGvpI+eiG",
+	"+5yZ1oa8QwCkOdqh8+KuNGGSLEngLEHBgWAZ8mA+aybgZF2Qrk6LUIl1t1gssSaHw/MzDlYJFHKVwQYk",
+	"8SXh2UxnvVGWv+Kb250yPMNx4S8KXZz4EFmO2jaLsblpZ6UknXdnxekgoviIGPeqJaZviR6dF4TiYpwb",
+	"89UPFO0rndHTCL95YfmW3hItv3eK6WwopUeOIjWTFaMLhjjfvM9GkmPG9Ne0iwxzOJwf+U5iH+iMJpOH",
+	"ppYvb2Iellr0cVS27DyWyvSq9dOB1SQrpoDFwb10X5VSZJEYQbluzqKBjffT6fmO/Gey83Z6vvnkyrAd",
+	"W6vDYMMknR2A3c2768YY3aChlyMKpdWEQowKKe1vrca6eLFAbYPR3GR+0husUlVzeNVnHOA0RTGGAikn",
+	"aD+WejQ1voaudp0eLwgUGfOg500pIRfkLa38yDGjMonwgqDYECf3cjFeEEwWrcc/mpIZ7YkE2Udp7Ifp",
+	"7e8QPXbYo8I4UGCRxcjrLE0oWTS9rUJg+3G/8kEziqdwMSJz6nHeZGJJGf635nVMNEkpvqcMQAJGQyDg",
+	"osb86OsKs7Wf+ocqS9SqXboDoD5Q6+el2s69fgWlRFYz8ayuemmHkpAvGM1WKuE4n13Fb7PbY9Cm/aGM",
+	"tdqu4Lg23iQ0ulZ/HSkEaGGvcmEC5YA3G/b064OEvSS2pATVERHME3iYKPcvQPItMJqQpOSkjCuQYI9H",
+	"CfuxP11W7YQymj12h0OPbZpiQbh1xXWqqLLoqh9ajjEXPdxsESUCYqK1bZ3RmiBxB1TJh41KjEqStXEp",
+	"o9CQfLvqWJIesZDEO22f55bBtVIrSwNJ4sCoFPRrW6Qm2usKUbkoaoS5cVWPi6/vvp4avRIAR+d9NgvY",
+	"gqcmdPj1sEFVl8v3rOpsYRxLJdm7I0XGNK+/oJTFmNijCW004u6H6svMiidPr+rdldyrvQ2khdjf2FRW",
+	"6/dGWZ/bncQ4xPpsRNeYLOqhxuOz03dXJ2fTs/GnwX+rCNL4w+j03dW7wXjw7sh5cHw2DcLg7PRqOB59",
+	"PNKNz06vJtPxkQqwXpwOj8bvxmcXp0P78ed+O6RYXzXEYFdU2hQ5Ujs6q1CgpQ5DC8X6VVarTBIORH6y",
+	"XdzBMZ/Qhdcjb5If1KmGTY+JsvCqX4iL3Ght0d51S6W6a/tWahYJXTgSsp8KTpO455C65SMMyVBKBTru",
+	"YaMp1D5CYKKWBVMCwEcCCV1M/YcV1ytlDMiJCwqsseWoWI5j/JhKRWBizoPJX5+9+FAkNWp2eZoWSouk",
+	"QDAYXWtXm4SiCLI12YK/TjymZujoVXJxqNauia27/FoSn+0Rij/L29RCFOOCGiDnNMLqVJA6+6aIIofc",
+	"G8268/y9YQntDvKGKDJlob6BsY0slFPczEletdOfI5ZiLtWHISL4gV6livfe5w62L+oqk/Vjm0aAMnAx",
+	"HvXx8hTpSD2c7G9VY+tlTyBZZCYuUUnCMm+A3LzABtpebIfgb4j8Tf7L5b8x+lvFpf53xTq5ddMjYVah",
+	"I59BC04dsGugnlQwp3s7uCT/Ab4MJoej0RewBc4TKC069FWo5++nJ8fy8RhHS/XUfCUwWagGF2P12cX4",
+	"WAo8EwMBGziFCxSCWzRbwQXaVMfYciVHjhWEgexb0uN45BW2vkhN3U1gBrRUYcMQelanEtbkcB0lSE2C",
+	"ivzsKVWJgeYzrlqPyFtGiZAtJ0t6C2ZoThnSLbkUiIxqfUFjLLmFa55/oX+CG8zxLEEhWOLFUrK+BaiE",
+	"AQcuZcqrXoIwcPpsQ0kRAKqLB5M+rY/lawdKJWY1Q0WoSqPJfiTnMdThIRgJfGPcuKo7pJhfNX8Ls0Sg",
+	"WLZWcTGrRS0hB5AAxBhlGqGxxrtqZYoGJAjMMqE8lJiAjCNNRSR/nX9AM5XdyBG7wREq4c8CHISBAUai",
+	"0Ui9oqsGHNqsap+tY84/p7KRzdyGwi10kmtVdzvvWCoFYVOOGLLy+aG1Hfx7iEobj5smaw1308xMt6/F",
+	"7hxenLjjeMJxollnrW3EGvMFYvrtwR1R0KkT5xwNVXBHmhU6GOZ8u9npsHVXv4Rev0zOUdTsXjiHC2Xr",
+	"xNqVUCE+j0vBHHypyHZzqpg42qJKIJdaW8aIm2tRCrcXJ1CbCcQBCDAUURbfg0p8hEHnc45Eu86rZ8Gv",
+	"8WrVMAlBhU+VncrHDkJSKKKllGXFFDqU1rR0PlcPY4/t5MB3LPyknQeBTqUt86CUjLDGCR4d6avX7FUf",
+	"ANPAqiQajm19+AhHIXB4YvsNWmDiDW4WOlMlhKrgNOmZG2N4K/WwiYqyDKGA3r6aY33WwNPEBnnGUCo1",
+	"lI1DqDbTo48hGJEEiRCcZUL9/4bG64YsUPk9JHGzRVgaQqPniCC2WG8P1La3PUqlBrw9RgvMBWIhOKe3",
+	"iJXfegdfLaGXx+VjO2wMNo73QnC8H4LjFyE4DcHx3pb8d1/9+2JLP1Hv97dkk+MXW8d73vEy4hMGFwSL",
+	"2jw/LUNwLf+5gUz+qf/7JB+G4OMgBNfynxvI9LsQDELwMQQfQnCIEo4zHoK3cMkQWSIsQnCOWISIHwsN",
+	"pyhO7Pw1kW+QLEUMRwByk/TbLX5vGmVtbqz0yX+lrFQ1BVD7cV3e5q9ajP5qMrG0+q2XOP++Zux1R4hG",
+	"BAsME18fVhMqipzk8aJ+qa2atlkDQw5VwrXOecEGishfY0k2OTs8HwHm9AhWjEba21dGZ3cRF6sIlLoz",
+	"NrYKbuuX2rDGHKSQXaNYEtGX8dG70WR6ND4aftGlkWRTQa8RyQvpQF1ZCQh6SWZF5BZGElr5FiASrygm",
+	"ggN4Q3Fs15EgU5Sidb7tAF6SL+dHp8PR6Ts/fJQk6zKQFjDZ8MsOjVZ4x4QK+JfQPtnf3v+iCpEUv3ci",
+	"hhRRwoR/uST5nLZLarQBJgiDAnP+MjgSRv+iafCdsk8RTdOMqEoRZGF9HQigk8k52DgcHw2PTqejwfHk",
+	"anr24ej0aqAyo7rqY2Us8Q8v7U5DMGoEi518GdWK2FwInbM1OZlofMNIyGXRNW5IXARe8l4s3dX9mB1q",
+	"okLYZy/fSYOmJZ5WnOrKG3Lf6cviZd8ohjN0LiR7HEMsBuqYT6/SewxJuxQ6ZV+cIe5mUukyQY5Zpby8",
+	"sjPUL8TZln8wmpyBv7/e3XO86Hk2ggNxV0qCP2zdFf5WjHS7VD6X+rkKaWcXU3Vx2SNs3poCkUcQdCtg",
+	"A+RdnToIucM2uVTHMd3Ff0gRiNJyhnlsvwxaJwW36A75kpvd72HE2o9CNbvEA3F/Ar2F3HBd/xMNPw1j",
+	"5AjNScl/qOBeVP/jyLzb/V/VldzuPRlEhZfsLIqyFa6fmCqcZmFwCEmEkqSUcfS5O1TnIifsw5stIQLJ",
+	"b8LZUMqcJloDfhIStdmsEJOodusC07k03d+XD0LetSDpBIlKfZtGSLtKbLQH6yJeGeeudYE6JKan/4b5",
+	"lo+gNE635/GNyoGWut+l+QBBU1zw/XR63hQJVB5pv2hRrxyJfo+qk8B98YCo2NSvZA9IJQNI65a1zQdG",
+	"S3RiMjOqZmRsy4kuoVCF9JTgUJq7/E4q6phbs8OVIMefBv89kcbl8fHZp6Nh8dfV2du3x6PTI3UQ+uPR",
+	"2F8piRJpC4uW/VC9Vz5ZdDIYDTc9cVJrY2zouE298qOpt0iZys83JSeDg2Djn4Ot/we3/v352/73zY2t",
+	"/9wsHrwoP9jd+uPztz/qzzb/Mwgbk4sOvcjW81INdEjQKest8SytlIpG1RENDAOVh+pHIuYAxzpRlStN",
+	"MFslxeoqPTGF1wiIWwooAyllyL66pexamj+UoM4TP7aet4e4zLzkckCyDkFKeV52RakItXqipilYMSnq",
+	"YlsMd/x2NAQRZHGookMEScsXMpysc/POf6hEB2Cbl2PF0BwxhmJg21p71SZzQw6kWvP6xR9be0Ujk450",
+	"p6Uqkg4aaD62Feu1F1qpZyr5QGcdxGADLwhlGi1ab9vRr/ofJlMpU01Mp15KoukkzBel2b5oKY/rcQu4",
+	"QsaVKMOr92eHVxeTo7EUJufn9s+z6Xv1v6QCrzDxntOSQ2Va7dJCAsc9aFlnTntI2ZyKUz3Z9GpPkRjM",
+	"s+YS+6qkrGqxwxCMdWVZ1XbHaoaR9Rnl9A9JQf49CmgV8qdY7NCWGdbnyBzZmzOvnXno7Ba+neiCJDS6",
+	"ziOWfZWbCjaHTqEco6VLtlN9P7S+XxhoJsuzeO9wNOlO2eqdGbwE3VazdzfSjAswQ2Ch2FeaAJDYVN/N",
+	"R86+9iVdK8dhHO/kiUwPTcHuynvVA7Wn4Rnsb7zNkuQfpuC3vQ5BYjkEQzyfI6a9lv+wh+Vs2N1MbdOR",
+	"JbInVTe3+KxbqS8njDuA+4jsoyn6zGs15lpKo4iiVnSp9FtDeqltzH1BNvPKdNxcQSsvQd0QZ9ThurwX",
+	"j0pjyMFzuLz9xG57rkPpREedynFTfkPrd75whq3K7QOmWiHchwDiLWVwWCpC3imYVSMfHdk1ruOxGe6P",
+	"1YLj/cH+6FY0vy/UNXlsKcSZTlglvDuXuSuovxf/9SttM0GiYJ1W5mutYpizcd9ShjkyJr2KElb671vW",
+	"5tBZCVvWplgQN4FzYOExqbeVgoaf7yYILK09Og88qOM7kunkCcox5rTWTJ8FOdbKMPak1JZtwkaM8ia5",
+	"5YyZJ6mrKsh/S/7fkr8B6lyAtIyUs1YrkamZiPYKncUVGxzkX/gMsDQT9mqufh2aogFazroOrjGC8Zku",
+	"BvqJYYHM3/Kx+u2VkSupPnJ/hrp3ePMBBzBilEsZIOUwv0sF0o8llTLoleLRUdvTKyjrK/+oW/p3xbD6",
+	"zK46Thnp8qApxElwEKQQ3aAtgWD6f8SSZouluKXsmm9HNA0syQcn8OgjArJRvRazOr5CYAIG5yN9b5FA",
+	"ysOY+xL114eTk0kI0FfTWt8elR9gyrhO8dhW2X4RMiLdjD9YSeNZymmd2yqSAip1H1AY2POgB8Hu9q5u",
+	"R1eIwBUODoIX6pFyVC4Vd+xUblFaUZ+NoY9tKCdf7a4rYG6GksPrW2ZUkoMkezkXUb5WSpmHmVhKQatv",
+	"yvIEmTOOyQKkmchgoq/ZskE++aNImFKVZnUhFTqfm5IccgAg/96awURKMKYTT0rJVGZG5StRTMLFGxqv",
+	"KydB4GqVGM/Jzv9wbY5r07UzJuKM8L1MrdKc1YE9tSmr5djf3fPsByaCqijOXPf3SOAZlURBVg0ooq8r",
+	"pf3pOIViNZ6lKWTrHH+SIEoTDEsEtfOtcpfidz25BHmrLqjnTUS2hEIlH8wQIvkRP5f2DNXAym15pcvy",
+	"LolRf4dHYzBbC8R9tKEBKdPGCjKokmK5un4CS4AlExWioTLVoLrUobMk7SlH3z/XqOKlJ0+Z2sM0kjBe",
+	"6iZPTBSnVIA5zcjzokW9XlVaDIOFL737mNLrbPXjiUzD8ayIbPfppF7zTbA2/PkXp+GCLGvylO98i/go",
+	"/t68PdtccSk7Cbr1Xu3I11yg1OQecp6lhtzr2+8lkSxAqABrJDQrqBxGqVWgWCV7ql60F9WzfWOi9mBT",
+	"CU2fBrsknAIsjDaMSF7BHsV6d8dC5UHKKUgFVY6fRyt8/GPnXLo+rs5DngBpBVjX5vNxHM+vCqmxlecS",
+	"ZM1WT6BH1O6h/ZW0CbuYXvqtsMEONLfwesX7WJ040nFfmylukQRm60KQL6BAt3CtDo5KckkxQWBJb/so",
+	"qM3ivLZKz4Qgn0rO+6nScyzUubAxE8vcE/XniX3jrazR1rPigoJ2HRJ00z6rrODeFN64PWgHNi8fCdEF",
+	"qRuqcgLKPHeCb1+SC3NmQcBrBCRbrdQBn/JxWZV6mEJp/xJ1W6n6eY2kjC9O4sIFxFKyG48xBzMqlsV1",
+	"pHKbKXySvh2gfv/6Ly3+G+6a77UN7HuCt8bND7bKV6rn8QYdVeTZLMXiue0Xh95L9EvcUOEUlXSwEyUI",
+	"sjY9Sk2a+5QaQYH6GmDBvSF8NcI2uCQ6Mv9VVN5bjCrd6V8ZYmvHbXJ/JpAwlQLnhxKOZ7nvtFOhwp/B",
+	"8TOnPgWjZ/UBJR26S+3Ocr8rpIMQY2vwFjLasajyhVQKjyRXaZWqayy0BOeapmpuDn2wI6U3da9dwzUb",
+	"Ld4TVzNotXJ/GRFdNs2HUMC7y+hHgaR+HNVD4zZtBBoODLVgMqTlrn35jv9n7/lpotUWVuSN5sT/zRCz",
+	"9derZaUpc0qQu71tg4LJ3iGRV8N2KGQU80viFAYrTSBnV32m0enZJnKVqp+bFNZuzmyAhT8Dngwbz8XM",
+	"cSINw9m67KnTSQVqZLWXel1kJvWggMKG3j7uvxtTKio3op/Vn8nduf60fA/74RJiiewTSLI5jETGEKt+",
+	"87n3/vjDJYBWTaqq1fOVAe+QaODDZkkQ5gpgmUMMezRtXvwv4l+yaHBn3msP2/UccPvwrKjFTK1MJ14J",
+	"WtsvzGmlLXODubNn1MRs7WRTL9++poRmh75HaHoFYO2OY0NYrRUTG/pqupS+LlOnX+25rzCYfh3qBS8e",
+	"aQI7p5iIE5g3/Rz2nVXprvyek3py11flan0POea309piZvn99789X2UZ7sWQ306fIMGtz8r5QtdW8Tiu",
+	"GlUk5c5SdzSkkBUghCp/AOj8AfVbGuLxmsAUR2DFsHzo07DqhzOfhvOfaBNoPlv6CF6m2mpZI/9fGcq0",
+	"hf+bHww/TDz80LUf7Xwzf5hQYeFb8HiM/hQqDb3d5FC2B6/vs1n93vgaN74O3lQerd+M2dP118mackSO",
+	"Bdqy1ye1Kou29cQ2/nHa4uMyZJzlNZyLjvK1fPF6160Yvnd35hxDgS6IKojo6T8YOMm2n4IwGPQzwx9R",
+	"R6ytrC88ahvld2395riqauhBUZXjdDZJXlKuKTlAeduMP8+UMyl9642G6qSvPCqjeNb5ZvuSWHdVsnYc",
+	"Vq4i6oxwjda8wT1XdjyU5vRknodeCWS9fHaHNE3hlqmI4NSUrU+/cieCj8ev0TroVIGfjG8dgNtcaKWG",
+	"v5MaWk27gjDL9LBh+WpTlw8Q0bI5haH8qTniSkkny+rvq1xrEy72d/dBrg2pbP0VYlvXaG2P3W2DCU3t",
+	"GQ4OUri2SUUAmhMVzRkKPxVTP5V70Z12+UDznxwc80LSzOGuklyiPZMnoQuUit9qco/8jGa+L2/mMRRw",
+	"S1VGn6OWbI2JShe9QSSmbCvfa1XcTOWf+rJgbVQthUL5dDhKIRE44pdEXWSqSs/miYK67wdkZ0z07ehw",
+	"aifzy8YP3Fn+IM4ug9CLpTWxmG+eedaJpKUKwIJ2xCzi4pKpZj4aGRHGAQTOB/k9TzaIZlgMxf4bzCQn",
+	"b+vsp8p7FVaMaJKgSJRGkAxkRhFLlNqDFnnFXFu03Z//rRartLk6d2r9dbZWZ9KP6K11lymvJ/189rpK",
+	"3qyGz4XZc9NeC3PsFJX2OrPKrdnoYRWTUGsrdTcxTB/jz1nVSV5Y8DkS9BOZYPX5e6jDaWRx/3xssJoV",
+	"1EgwdcJUFSq3nIKWbRoQzC9ZErR0wZI/7AV4xBBSKd7HR0Pb2k3EttdGhdbdokJg6hjP1gxyFNuPdFws",
+	"zRKBV0n1bi++fUkK7UjVl28ImVUqcv6yOlJjKdNHkNeWBJ6X7x7Ye6LyKmVUqlemRMyzC7nFlQvdOtN5",
+	"K5y68838UQvBVbeTlN4ofSs3W+yQDSlLDpv24CkVpXh2XBW23ajoFK62mfb+UXMMP3U07DcnPShGVuWl",
+	"XgpZiZva1DEnPT73Muepsc7R0goUvCWR3e/CVzcZUpbvif0Y8F1V0j/LHNu3epo5bmZr585FYao3+iPS",
+	"ohwK73GnaXFvZD9ILMIbYHBe3wmM0o2edxcNCyR+C4aHhAL8DNkuF+aYpbeQoftYafZbWwK0p4kWXhJM",
+	"oiTTt9mZvgyGw/xku0X5Bp4DSNabofFoqJFWjC4Y4r1CfW8NlE9t6j0L064yWQ8d2RbPz6h7Ztzkp+5G",
+	"/snyG8m7PYHVro0t2ejTqDjJGVpkCWSXRHnZ1d2M1S65dsn7nIUxvSW6vhCJbXK/Gt52cUnyjbyXt1BX",
+	"bPby3K9rb9oZ6sk/orFZpY2SY/DZMMiU4cUCMR8lt+836nTvVmJqXndvNTRdqWNoTYW97+sQPPbX4f61",
+	"dwf/pNviOcdNaH8u24ZU0Qg15KHI6rntI40l6RtT8LVM4a0F7Tv3jGrxh3mWJMCUZ1d1JVTavVNiPd85",
+	"GkX88+aZx5fxDVcRPIKQLy5+/Z0H7Cl/qLaSZr5p2lF2booLHXobMZU7Hkx5uabBLwkX9hKX3geDcwoq",
+	"7if45XcZZ7rd+4sSaHYhfu8sD91ZLCrrnLLomaqQ0MVdUxS0005R+2Kzb1LBsYToL5NNcEwXj7iHyDX6",
+	"WbIHqvTUZSMs7pU14IzyiNkCx3TxbLMEmpy9boK8pRF1Na3P3WsaVDaQP/XAb4Fj7x6x+AkyEGrEV6Vq",
+	"RTdb5tqG7lMUSyw1DSwlvPoyv3MIEcQWKhDDs1R9F4IVvUUsBDc0EXCBQoBEtL0JLglD2lVtky4b/Uo6",
+	"KqPK75IYrOACkzYGOZEQfbQ3UDzX4MtsXb2Z+TFPNjYNqTIIYaRm2jio08jPd71YXEAm1F2MYMPe3rzZ",
+	"HFdiYqrvFSwG63PtYBsEiMQ9x0ckfqTRT+BXuS6Owm4OEpiDLxkjDTAkOG06z7anjsvpntWvHqfnKqWP",
+	"feDwa7wCGwU7NWGHzuf6Ai8PaLvhjyvE4PB5mxZ/4gooe/YoBjyLIsT5PEt0WZvfFq6zX5SEeg+liKE8",
+	"9N6StJbJySCuK/2WjgSogtTmHowZAmrWRf31ej4/5gCrStWXRBUbNcXaZwhkXN+sCsFC7kUwqcr3vKK1",
+	"umkCRUtIME9DgIXs0vZ2SeaqeoS+TTY//5MXFI4ztR8JxAUmi20wmAuVR16aVuitsa3iHDNkTg9JStSz",
+	"rGMlgsTUW53PUSQAnquQCMvU2gnqN2TylfgrFsieICEX5JepWuQsZ49KRe6N/M1FgVUZcK7Or+XN715B",
+	"pSmCN0NlIjWjoMqlrDcY6uyFsX59Sm+9CW0K2LEzr7+MQe5M+hENc3fNGwz03T+B7N/A2A7/e/N1U+gU",
+	"vas71S2nuEzdzO8735wfHVmoh5BEKOEAEiC1/BtUoooHM3ykujfXjRf95hyvh3fI28v41UY/g4NjWply",
+	"FwClJWuFpPPy5ntUXZYITlolwY/1b5cI/znxqKZv2JMzm/0px+p6PrdpH5/gmzUwqDAGJfdwMW/MUDVB",
+	"9QK6n8px6HKXcbttGGwcGDS0OBm0n9RXMUZ/6pSNKR58XalJhAFMkj+7joyzUF11BksU93tLdS5YMhkh",
+	"DnbqvCpcfblqUfGK0/2nKu2nwH+oAqk6yXcJWzfYURer0bobmOCShvfK385chalMANZgAZlBq1JIL1tl",
+	"LYVO/WpeTZMb9le0jc3Uf2bTuLLaGUlodL2V68rNy36hWuYXRf9UHFyB/aG8rLv7scwsKNBrV7J0POV8",
+	"qvxdupC8I0hV3EyuPJhtlYLy/ID8XvSmc0H5+gBI4h3KivuWJdX0CdnmQ/xcmldUvZvcH64q7ne+V9To",
+	"pnKVuG8Q5+LoH1MlrH71vkd61S/f/62VtVcHK/jVSdppqw2mqkHflO4o76wJpjl9Uub09nJg+Qi2JlhL",
+	"/eefgcmfaJvKp/xDq3zVoOhVDqi4s/93ca8exam7eVbu2vZYzs43+1fvu2ztB8UN+uq2tJbbYI/NF334",
+	"Le+9i9MKuIO73q/8FAl6kVWJfr37X5sXXdMSM+16kQ+Ron4EVpCJdYWCwBDZM5zWz10KueZnyvLrYm9x",
+	"klwShMUSsVwuKOefHI9VINZjGieeBSBJwC3ExWkg/VzQortL0tRhF92fy76Cp3IdFBD9qlTXTCua8AS9",
+	"RqTDg6vOKMp2XCcy6KuudSqCuVSYMvxvlCsmDW7ZqeqjwTbtTsq5T6HuetaRm2fUkWb0UB0bC5TyrkVW",
+	"SJHUY4aHjMF1myNUr8Tzc0GWU+ELKNuj9JTZo08A6o/uT2MTpEnsicSFWalfSE5omMzpaRUura+hIyZ2",
+	"vqn/LrBWc/wSw173/8C11P3Y5ex2ZlnI+hoOL17/uZEOh3gqWnod5cWl2H+Wcn5K5e6dkedFnpaWmuhS",
+	"Nla+uDZFOAExukEJ1fd56/ZBGGQsCQ6CpRCrgx19im1JuTj44+Xe7g5c4Z2b3eD75+//PwAA//8iDeph",
+	"0/wAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/manager/api/render.go
+++ b/manager/api/render.go
@@ -119,3 +119,11 @@ func (r ResetRequest) Bind(_ *http.Request) error {
 func (u UnlockConnectorRequest) Bind(_ *http.Request) error {
 	return nil
 }
+
+func (c CertificateHashDataRequest) Bind(_ *http.Request) error {
+	return nil
+}
+
+func (o OperationResponse) Render(_ http.ResponseWriter, _ *http.Request) error {
+	return nil
+}

--- a/manager/store/cs.go
+++ b/manager/store/cs.go
@@ -281,3 +281,51 @@ type UnlockConnectorRequestStore interface {
 	GetUnlockConnectorRequest(ctx context.Context, chargeStationId string) (*UnlockConnectorRequest, error)
 	DeleteUnlockConnectorRequest(ctx context.Context, chargeStationId string) error
 }
+
+type CertificateQueryStatus string
+
+var (
+	CertificateQueryStatusPending  CertificateQueryStatus = "Pending"
+	CertificateQueryStatusAccepted CertificateQueryStatus = "Accepted"
+	CertificateQueryStatusRejected CertificateQueryStatus = "Rejected"
+)
+
+type ChargeStationCertificateQuery struct {
+	ChargeStationId string
+	CertificateType *string
+	QueryStatus     CertificateQueryStatus
+	SendAfter       time.Time
+}
+
+type ChargeStationCertificateQueryStore interface {
+	SetChargeStationCertificateQuery(ctx context.Context, chargeStationId string, query *ChargeStationCertificateQuery) error
+	DeleteChargeStationCertificateQuery(ctx context.Context, chargeStationId string) error
+	LookupChargeStationCertificateQuery(ctx context.Context, chargeStationId string) (*ChargeStationCertificateQuery, error)
+	ListChargeStationCertificateQueries(ctx context.Context, pageSize int, previousChargeStationId string) ([]*ChargeStationCertificateQuery, error)
+}
+
+type CertificateDeletionStatus string
+
+var (
+	CertificateDeletionStatusPending  CertificateDeletionStatus = "Pending"
+	CertificateDeletionStatusAccepted CertificateDeletionStatus = "Accepted"
+	CertificateDeletionStatusRejected CertificateDeletionStatus = "Rejected"
+	CertificateDeletionStatusNotFound CertificateDeletionStatus = "NotFound"
+)
+
+type ChargeStationCertificateDeletion struct {
+	ChargeStationId string
+	HashAlgorithm   string
+	IssuerNameHash  string
+	IssuerKeyHash   string
+	SerialNumber    string
+	DeletionStatus  CertificateDeletionStatus
+	SendAfter       time.Time
+}
+
+type ChargeStationCertificateDeletionStore interface {
+	SetChargeStationCertificateDeletion(ctx context.Context, chargeStationId string, deletion *ChargeStationCertificateDeletion) error
+	DeleteChargeStationCertificateDeletion(ctx context.Context, chargeStationId string) error
+	LookupChargeStationCertificateDeletion(ctx context.Context, chargeStationId string) (*ChargeStationCertificateDeletion, error)
+	ListChargeStationCertificateDeletions(ctx context.Context, pageSize int, previousChargeStationId string) ([]*ChargeStationCertificateDeletion, error)
+}

--- a/manager/store/engine.go
+++ b/manager/store/engine.go
@@ -11,6 +11,8 @@ type Engine interface {
 	ChargeStationDataTransferStore
 	ChargeStationClearCacheStore
 	ChargeStationChangeAvailabilityStore
+	ChargeStationCertificateQueryStore
+	ChargeStationCertificateDeletionStore
 	TokenStore
 	TransactionStore
 	CertificateStore

--- a/manager/store/inmemory/store.go
+++ b/manager/store/inmemory/store.go
@@ -35,6 +35,8 @@ type Store struct {
 	chargeStationDataTransfer        map[string]*store.ChargeStationDataTransfer
 	chargeStationClearCache          map[string]*store.ChargeStationClearCache
 	chargeStationChangeAvailability  map[string]*store.ChargeStationChangeAvailability
+	chargeStationCertificateQuery    map[string]*store.ChargeStationCertificateQuery
+	chargeStationCertificateDeletion map[string]*store.ChargeStationCertificateDeletion
 	tokens                           map[string]*store.Token
 	transactions                     map[string]*store.Transaction
 	certificates                     map[string]string
@@ -69,6 +71,8 @@ func NewStore(clock clock.PassiveClock) *Store {
 		chargeStationDataTransfer:        make(map[string]*store.ChargeStationDataTransfer),
 		chargeStationClearCache:          make(map[string]*store.ChargeStationClearCache),
 		chargeStationChangeAvailability:  make(map[string]*store.ChargeStationChangeAvailability),
+		chargeStationCertificateQuery:    make(map[string]*store.ChargeStationCertificateQuery),
+		chargeStationCertificateDeletion: make(map[string]*store.ChargeStationCertificateDeletion),
 		tokens:                           make(map[string]*store.Token),
 		transactions:                     make(map[string]*store.Transaction),
 		certificates:                     make(map[string]string),
@@ -1107,6 +1111,90 @@ func (s *Store) DeleteUnlockConnectorRequest(_ context.Context, chargeStationId 
 	defer s.Unlock()
 	delete(s.unlockConnectorRequests, chargeStationId)
 	return nil
+}
+
+func (s *Store) SetChargeStationCertificateQuery(_ context.Context, chargeStationId string, query *store.ChargeStationCertificateQuery) error {
+	s.Lock()
+	defer s.Unlock()
+	s.chargeStationCertificateQuery[chargeStationId] = query
+	return nil
+}
+
+func (s *Store) DeleteChargeStationCertificateQuery(_ context.Context, chargeStationId string) error {
+	s.Lock()
+	defer s.Unlock()
+	delete(s.chargeStationCertificateQuery, chargeStationId)
+	return nil
+}
+
+func (s *Store) LookupChargeStationCertificateQuery(_ context.Context, chargeStationId string) (*store.ChargeStationCertificateQuery, error) {
+	s.Lock()
+	defer s.Unlock()
+	return s.chargeStationCertificateQuery[chargeStationId], nil
+}
+
+func (s *Store) ListChargeStationCertificateQueries(_ context.Context, pageSize int, previousChargeStationId string) ([]*store.ChargeStationCertificateQuery, error) {
+	s.Lock()
+	defer s.Unlock()
+
+	keys := maps.Keys(s.chargeStationCertificateQuery)
+	sort.Strings(keys)
+
+	i, found := slices.BinarySearch(keys, previousChargeStationId)
+	if !found {
+		i = 0
+	} else {
+		i++
+	}
+
+	var queries []*store.ChargeStationCertificateQuery
+	max := int(math.Min(float64(i+pageSize), float64(len(keys))))
+	for _, k := range keys[i:max] {
+		queries = append(queries, s.chargeStationCertificateQuery[k])
+	}
+	return queries, nil
+}
+
+func (s *Store) SetChargeStationCertificateDeletion(_ context.Context, chargeStationId string, deletion *store.ChargeStationCertificateDeletion) error {
+	s.Lock()
+	defer s.Unlock()
+	s.chargeStationCertificateDeletion[chargeStationId] = deletion
+	return nil
+}
+
+func (s *Store) DeleteChargeStationCertificateDeletion(_ context.Context, chargeStationId string) error {
+	s.Lock()
+	defer s.Unlock()
+	delete(s.chargeStationCertificateDeletion, chargeStationId)
+	return nil
+}
+
+func (s *Store) LookupChargeStationCertificateDeletion(_ context.Context, chargeStationId string) (*store.ChargeStationCertificateDeletion, error) {
+	s.Lock()
+	defer s.Unlock()
+	return s.chargeStationCertificateDeletion[chargeStationId], nil
+}
+
+func (s *Store) ListChargeStationCertificateDeletions(_ context.Context, pageSize int, previousChargeStationId string) ([]*store.ChargeStationCertificateDeletion, error) {
+	s.Lock()
+	defer s.Unlock()
+
+	keys := maps.Keys(s.chargeStationCertificateDeletion)
+	sort.Strings(keys)
+
+	i, found := slices.BinarySearch(keys, previousChargeStationId)
+	if !found {
+		i = 0
+	} else {
+		i++
+	}
+
+	var deletions []*store.ChargeStationCertificateDeletion
+	max := int(math.Min(float64(i+pageSize), float64(len(keys))))
+	for _, k := range keys[i:max] {
+		deletions = append(deletions, s.chargeStationCertificateDeletion[k])
+	}
+	return deletions, nil
 }
 
 func (s *Store) SetDiagnosticsRequest(_ context.Context, chargeStationId string, request *store.DiagnosticsRequest) error {

--- a/manager/store/postgres/charge_stations.go
+++ b/manager/store/postgres/charge_stations.go
@@ -5,6 +5,7 @@ package postgres
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
@@ -578,4 +579,129 @@ func (s *Store) DeleteChargeStationChangeAvailability(ctx context.Context, charg
 		return fmt.Errorf("failed to delete charge station change availability: %w", err)
 	}
 	return nil
+}
+
+func (s *Store) SetChargeStationCertificateQuery(ctx context.Context, chargeStationId string, query *store.ChargeStationCertificateQuery) error {
+	_, err := s.q.SetChargeStationCertificateQuery(ctx, SetChargeStationCertificateQueryParams{
+		ChargeStationID: chargeStationId,
+		CertificateType: textFromString(query.CertificateType),
+		QueryStatus:     string(query.QueryStatus),
+		SendAfter:       toPgTimestamp(query.SendAfter),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to set certificate query: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) DeleteChargeStationCertificateQuery(ctx context.Context, chargeStationId string) error {
+	err := s.q.DeleteChargeStationCertificateQuery(ctx, chargeStationId)
+	if err != nil {
+		return fmt.Errorf("failed to delete certificate query: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) LookupChargeStationCertificateQuery(ctx context.Context, chargeStationId string) (*store.ChargeStationCertificateQuery, error) {
+	row, err := s.q.LookupChargeStationCertificateQuery(ctx, chargeStationId)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to lookup certificate query: %w", err)
+	}
+	return &store.ChargeStationCertificateQuery{
+		ChargeStationId: row.ChargeStationID,
+		CertificateType: stringFromText(row.CertificateType),
+		QueryStatus:     store.CertificateQueryStatus(row.QueryStatus),
+		SendAfter:       fromPgTimestamp(row.SendAfter),
+	}, nil
+}
+
+func (s *Store) ListChargeStationCertificateQueries(ctx context.Context, pageSize int, previousChargeStationId string) ([]*store.ChargeStationCertificateQuery, error) {
+	rows, err := s.q.ListChargeStationCertificateQueries(ctx, ListChargeStationCertificateQueriesParams{
+		ChargeStationID: previousChargeStationId,
+		Limit:           int32(pageSize),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list certificate queries: %w", err)
+	}
+
+	var result []*store.ChargeStationCertificateQuery
+	for _, row := range rows {
+		result = append(result, &store.ChargeStationCertificateQuery{
+			ChargeStationId: row.ChargeStationID,
+			CertificateType: stringFromText(row.CertificateType),
+			QueryStatus:     store.CertificateQueryStatus(row.QueryStatus),
+			SendAfter:       fromPgTimestamp(row.SendAfter),
+		})
+	}
+	return result, nil
+}
+
+func (s *Store) SetChargeStationCertificateDeletion(ctx context.Context, chargeStationId string, deletion *store.ChargeStationCertificateDeletion) error {
+	_, err := s.q.SetChargeStationCertificateDeletion(ctx, SetChargeStationCertificateDeletionParams{
+		ChargeStationID: chargeStationId,
+		HashAlgorithm:   deletion.HashAlgorithm,
+		IssuerNameHash:  deletion.IssuerNameHash,
+		IssuerKeyHash:   deletion.IssuerKeyHash,
+		SerialNumber:    deletion.SerialNumber,
+		DeletionStatus:  string(deletion.DeletionStatus),
+		SendAfter:       toPgTimestamp(deletion.SendAfter),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to set certificate deletion: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) DeleteChargeStationCertificateDeletion(ctx context.Context, chargeStationId string) error {
+	err := s.q.DeleteChargeStationCertificateDeletion(ctx, chargeStationId)
+	if err != nil {
+		return fmt.Errorf("failed to delete certificate deletion: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) LookupChargeStationCertificateDeletion(ctx context.Context, chargeStationId string) (*store.ChargeStationCertificateDeletion, error) {
+	row, err := s.q.LookupChargeStationCertificateDeletion(ctx, chargeStationId)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to lookup certificate deletion: %w", err)
+	}
+	return &store.ChargeStationCertificateDeletion{
+		ChargeStationId: row.ChargeStationID,
+		HashAlgorithm:   row.HashAlgorithm,
+		IssuerNameHash:  row.IssuerNameHash,
+		IssuerKeyHash:   row.IssuerKeyHash,
+		SerialNumber:    row.SerialNumber,
+		DeletionStatus:  store.CertificateDeletionStatus(row.DeletionStatus),
+		SendAfter:       fromPgTimestamp(row.SendAfter),
+	}, nil
+}
+
+func (s *Store) ListChargeStationCertificateDeletions(ctx context.Context, pageSize int, previousChargeStationId string) ([]*store.ChargeStationCertificateDeletion, error) {
+	rows, err := s.q.ListChargeStationCertificateDeletions(ctx, ListChargeStationCertificateDeletionsParams{
+		ChargeStationID: previousChargeStationId,
+		Limit:           int32(pageSize),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list certificate deletions: %w", err)
+	}
+
+	var result []*store.ChargeStationCertificateDeletion
+	for _, row := range rows {
+		result = append(result, &store.ChargeStationCertificateDeletion{
+			ChargeStationId: row.ChargeStationID,
+			HashAlgorithm:   row.HashAlgorithm,
+			IssuerNameHash:  row.IssuerNameHash,
+			IssuerKeyHash:   row.IssuerKeyHash,
+			SerialNumber:    row.SerialNumber,
+			DeletionStatus:  store.CertificateDeletionStatus(row.DeletionStatus),
+			SendAfter:       fromPgTimestamp(row.SendAfter),
+		})
+	}
+	return result, nil
 }

--- a/manager/store/postgres/migrations/000023_create_certificate_operations.down.sql
+++ b/manager/store/postgres/migrations/000023_create_certificate_operations.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS charge_station_certificate_deletions;
+DROP TABLE IF EXISTS charge_station_certificate_queries;

--- a/manager/store/postgres/migrations/000023_create_certificate_operations.up.sql
+++ b/manager/store/postgres/migrations/000023_create_certificate_operations.up.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS charge_station_certificate_queries (
+    charge_station_id VARCHAR(28) PRIMARY KEY,
+    certificate_type TEXT,
+    query_status VARCHAR(20) NOT NULL,
+    send_after TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS charge_station_certificate_deletions (
+    charge_station_id VARCHAR(28) PRIMARY KEY,
+    hash_algorithm VARCHAR(10) NOT NULL,
+    issuer_name_hash VARCHAR(128) NOT NULL,
+    issuer_key_hash VARCHAR(128) NOT NULL,
+    serial_number VARCHAR(40) NOT NULL,
+    deletion_status VARCHAR(20) NOT NULL,
+    send_after TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/manager/store/postgres/models.go
+++ b/manager/store/postgres/models.go
@@ -35,6 +35,25 @@ type ChargeStationCertificate struct {
 	SendAfter                     pgtype.Timestamp `db:"send_after" json:"send_after"`
 }
 
+type ChargeStationCertificateDeletion struct {
+	ChargeStationID string           `db:"charge_station_id" json:"charge_station_id"`
+	HashAlgorithm   string           `db:"hash_algorithm" json:"hash_algorithm"`
+	IssuerNameHash  string           `db:"issuer_name_hash" json:"issuer_name_hash"`
+	IssuerKeyHash   string           `db:"issuer_key_hash" json:"issuer_key_hash"`
+	SerialNumber    string           `db:"serial_number" json:"serial_number"`
+	DeletionStatus  string           `db:"deletion_status" json:"deletion_status"`
+	SendAfter       pgtype.Timestamp `db:"send_after" json:"send_after"`
+	CreatedAt       pgtype.Timestamp `db:"created_at" json:"created_at"`
+}
+
+type ChargeStationCertificateQuery struct {
+	ChargeStationID string           `db:"charge_station_id" json:"charge_station_id"`
+	CertificateType pgtype.Text      `db:"certificate_type" json:"certificate_type"`
+	QueryStatus     string           `db:"query_status" json:"query_status"`
+	SendAfter       pgtype.Timestamp `db:"send_after" json:"send_after"`
+	CreatedAt       pgtype.Timestamp `db:"created_at" json:"created_at"`
+}
+
 type ChargeStationChangeAvailability struct {
 	ChargeStationID  string             `db:"charge_station_id" json:"charge_station_id"`
 	ConnectorID      pgtype.Int4        `db:"connector_id" json:"connector_id"`

--- a/manager/store/postgres/querier.go
+++ b/manager/store/postgres/querier.go
@@ -20,6 +20,8 @@ type Querier interface {
 	DeleteAllDisplayMessages(ctx context.Context, chargeStationID string) error
 	DeleteAllLocalAuthListEntries(ctx context.Context, chargeStationID string) error
 	DeleteCertificate(ctx context.Context, certificateHash string) error
+	DeleteChargeStationCertificateDeletion(ctx context.Context, chargeStationID string) error
+	DeleteChargeStationCertificateQuery(ctx context.Context, chargeStationID string) error
 	DeleteChargeStationCertificates(ctx context.Context, chargeStationID string) error
 	DeleteChargeStationChangeAvailability(ctx context.Context, chargeStationID string) error
 	DeleteChargeStationClearCache(ctx context.Context, chargeStationID string) error
@@ -89,6 +91,8 @@ type Querier interface {
 	GetUnlockConnectorRequest(ctx context.Context, chargeStationID string) (UnlockConnectorRequest, error)
 	ListAllLocations(ctx context.Context, arg ListAllLocationsParams) ([]Location, error)
 	ListCertificates(ctx context.Context) ([]Certificate, error)
+	ListChargeStationCertificateDeletions(ctx context.Context, arg ListChargeStationCertificateDeletionsParams) ([]ChargeStationCertificateDeletion, error)
+	ListChargeStationCertificateQueries(ctx context.Context, arg ListChargeStationCertificateQueriesParams) ([]ChargeStationCertificateQuery, error)
 	ListChargeStationCertificates(ctx context.Context, arg ListChargeStationCertificatesParams) ([]ListChargeStationCertificatesRow, error)
 	ListChargeStationChangeAvailabilities(ctx context.Context, arg ListChargeStationChangeAvailabilitiesParams) ([]ChargeStationChangeAvailability, error)
 	ListChargeStationClearCaches(ctx context.Context, arg ListChargeStationClearCachesParams) ([]ChargeStationClearCache, error)
@@ -106,9 +110,13 @@ type Querier interface {
 	ListOcpiPartiesForRole(ctx context.Context, role string) ([]OcpiParty, error)
 	ListTokens(ctx context.Context, arg ListTokensParams) ([]Token, error)
 	ListTransactions(ctx context.Context) ([]Transaction, error)
+	LookupChargeStationCertificateDeletion(ctx context.Context, chargeStationID string) (ChargeStationCertificateDeletion, error)
+	LookupChargeStationCertificateQuery(ctx context.Context, chargeStationID string) (ChargeStationCertificateQuery, error)
 	QueryMeterValues(ctx context.Context, arg QueryMeterValuesParams) ([]MeterValue, error)
 	SetCertificate(ctx context.Context, arg SetCertificateParams) (Certificate, error)
 	SetChargeStationAuth(ctx context.Context, arg SetChargeStationAuthParams) (ChargeStation, error)
+	SetChargeStationCertificateDeletion(ctx context.Context, arg SetChargeStationCertificateDeletionParams) (ChargeStationCertificateDeletion, error)
+	SetChargeStationCertificateQuery(ctx context.Context, arg SetChargeStationCertificateQueryParams) (ChargeStationCertificateQuery, error)
 	SetChargeStationChangeAvailability(ctx context.Context, arg SetChargeStationChangeAvailabilityParams) (ChargeStationChangeAvailability, error)
 	SetChargeStationClearCache(ctx context.Context, arg SetChargeStationClearCacheParams) (ChargeStationClearCache, error)
 	SetChargeStationDataTransfer(ctx context.Context, arg SetChargeStationDataTransferParams) (ChargeStationDataTransfer, error)

--- a/manager/store/postgres/queries/charge_stations.sql
+++ b/manager/store/postgres/queries/charge_stations.sql
@@ -176,3 +176,48 @@ SELECT * FROM charge_station_change_availability
 WHERE charge_station_id > $1
 ORDER BY charge_station_id ASC
 LIMIT $2;
+
+-- name: SetChargeStationCertificateQuery :one
+INSERT INTO charge_station_certificate_queries (charge_station_id, certificate_type, query_status, send_after)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (charge_station_id) DO UPDATE SET
+    certificate_type = EXCLUDED.certificate_type,
+    query_status = EXCLUDED.query_status,
+    send_after = EXCLUDED.send_after
+RETURNING *;
+
+-- name: DeleteChargeStationCertificateQuery :exec
+DELETE FROM charge_station_certificate_queries WHERE charge_station_id = $1;
+
+-- name: LookupChargeStationCertificateQuery :one
+SELECT * FROM charge_station_certificate_queries WHERE charge_station_id = $1;
+
+-- name: ListChargeStationCertificateQueries :many
+SELECT * FROM charge_station_certificate_queries
+WHERE charge_station_id > $1
+ORDER BY charge_station_id ASC
+LIMIT $2;
+
+-- name: SetChargeStationCertificateDeletion :one
+INSERT INTO charge_station_certificate_deletions (charge_station_id, hash_algorithm, issuer_name_hash, issuer_key_hash, serial_number, deletion_status, send_after)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
+ON CONFLICT (charge_station_id) DO UPDATE SET
+    hash_algorithm = EXCLUDED.hash_algorithm,
+    issuer_name_hash = EXCLUDED.issuer_name_hash,
+    issuer_key_hash = EXCLUDED.issuer_key_hash,
+    serial_number = EXCLUDED.serial_number,
+    deletion_status = EXCLUDED.deletion_status,
+    send_after = EXCLUDED.send_after
+RETURNING *;
+
+-- name: DeleteChargeStationCertificateDeletion :exec
+DELETE FROM charge_station_certificate_deletions WHERE charge_station_id = $1;
+
+-- name: LookupChargeStationCertificateDeletion :one
+SELECT * FROM charge_station_certificate_deletions WHERE charge_station_id = $1;
+
+-- name: ListChargeStationCertificateDeletions :many
+SELECT * FROM charge_station_certificate_deletions
+WHERE charge_station_id > $1
+ORDER BY charge_station_id ASC
+LIMIT $2;


### PR DESCRIPTION
- Add GET /cs/{csId}/certificates to query installed certificates from charge station
- Add DELETE /cs/{csId}/certificate to delete specific certificates from charge station
- Implement full PostgreSQL store with migrations (000016)
- Implement full inmemory store
- Implement full Firestore store
- Update OpenAPI spec with new endpoints and schemas
- Add CertificateHashDataRequest and OperationResponse schemas
- Uses OCPP GetInstalledCertificateIds and DeleteCertificate

Resolves #24
