### PR TITLE
feat: Add REST API endpoints for listing and retrieving transaction details (#13)

### DIFF
--- a/manager/api/api-spec.yaml
+++ b/manager/api/api-spec.yaml
@@ -574,6 +574,123 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
+  /cs/{csId}/transactions:
+    get:
+      summary: List transactions for a charge station
+      description: |
+        Lists transactions for the specified charge station with optional filtering
+        by status, date range, and pagination.
+      operationId: listTransactions
+      parameters:
+      - name: csId
+        in: path
+        description: The charge station identifier
+        required: true
+        schema:
+          type: string
+          maxLength: 28
+      - name: status
+        in: query
+        description: 'Filter by transaction status (default: all)'
+        required: false
+        schema:
+          type: string
+          enum:
+          - active
+          - completed
+          - all
+          default: all
+      - name: limit
+        in: query
+        description: 'Maximum number of transactions to return (default: 50, max: 100)'
+        required: false
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 100
+          default: 50
+      - name: offset
+        in: query
+        description: 'Number of transactions to skip for pagination (default: 0)'
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+          default: 0
+      - name: startDate
+        in: query
+        description: Filter transactions starting on or after this date (ISO8601)
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: endDate
+        in: query
+        description: Filter transactions starting on or before this date (ISO8601)
+        required: false
+        schema:
+          type: string
+          format: date-time
+      responses:
+        '200':
+          description: List of transactions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransactionList'
+        '404':
+          description: Unknown charge station
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /cs/{csId}/transaction/{transactionId}:
+    get:
+      summary: Get transaction details
+      description: |
+        Retrieves detailed information about a specific transaction including
+        all meter values.
+      operationId: getTransactionDetails
+      parameters:
+      - name: csId
+        in: path
+        description: The charge station identifier
+        required: true
+        schema:
+          type: string
+          maxLength: 28
+      - name: transactionId
+        in: path
+        description: The transaction identifier
+        required: true
+        schema:
+          type: string
+          maxLength: 36
+      responses:
+        '200':
+          description: Transaction details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransactionDetail'
+        '404':
+          description: Transaction not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
   /token:
     post:
       summary: Create/update an authorization token
@@ -2245,6 +2362,110 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ReservationResponse'
+    TransactionList:
+      type: object
+      description: List of transactions with pagination
+      required:
+      - transactions
+      - total
+      - limit
+      - offset
+      properties:
+        transactions:
+          type: array
+          items:
+            $ref: '#/components/schemas/TransactionSummary'
+        total:
+          type: integer
+          format: int64
+          description: Total number of transactions matching the filter
+        limit:
+          type: integer
+          description: Maximum number of results returned
+        offset:
+          type: integer
+          description: Number of results skipped
+    TransactionSummary:
+      type: object
+      description: Summary of a transaction
+      required:
+      - transactionId
+      - idTag
+      - startTime
+      - meterStart
+      - status
+      properties:
+        transactionId:
+          type: string
+          description: The transaction identifier
+        idTag:
+          type: string
+          description: The identifier used to start the transaction
+        startTime:
+          type: string
+          format: date-time
+          description: ISO 8601 timestamp when the transaction started
+        stopTime:
+          type: string
+          format: date-time
+          description: ISO 8601 timestamp when the transaction stopped (null if active)
+        meterStart:
+          type: integer
+          description: Meter value in Wh at start of transaction
+        meterStop:
+          type: integer
+          description: Meter value in Wh at end of transaction (null if active)
+        status:
+          type: string
+          enum:
+          - active
+          - completed
+          description: Status of the transaction
+    TransactionDetail:
+      type: object
+      description: Detailed transaction information including meter values
+      required:
+      - transactionId
+      - idTag
+      - startTime
+      - meterStart
+      - status
+      - meterValues
+      properties:
+        transactionId:
+          type: string
+          description: The transaction identifier
+        idTag:
+          type: string
+          description: The identifier used to start the transaction
+        tokenType:
+          type: string
+          description: The type of token used
+        startTime:
+          type: string
+          format: date-time
+          description: ISO 8601 timestamp when the transaction started
+        stopTime:
+          type: string
+          format: date-time
+          description: ISO 8601 timestamp when the transaction stopped (null if active)
+        meterStart:
+          type: integer
+          description: Meter value in Wh at start of transaction
+        meterStop:
+          type: integer
+          description: Meter value in Wh at end of transaction (null if active)
+        status:
+          type: string
+          enum:
+          - active
+          - completed
+          description: Status of the transaction
+        meterValues:
+          type: array
+          items:
+            $ref: '#/components/schemas/MeterValue'
+          description: All meter values recorded during the transaction
     ReservationResponse:
       type: object
       description: Reservation details

--- a/manager/api/api.gen.go
+++ b/manager/api/api.gen.go
@@ -303,6 +303,18 @@ const (
 	RFID      TokenType = "RFID"
 )
 
+// Defines values for TransactionDetailStatus.
+const (
+	TransactionDetailStatusActive    TransactionDetailStatus = "active"
+	TransactionDetailStatusCompleted TransactionDetailStatus = "completed"
+)
+
+// Defines values for TransactionSummaryStatus.
+const (
+	TransactionSummaryStatusActive    TransactionSummaryStatus = "active"
+	TransactionSummaryStatusCompleted TransactionSummaryStatus = "completed"
+)
+
 // Defines values for UpdateLocalListRequestUpdateType.
 const (
 	Differential UpdateLocalListRequestUpdateType = "Differential"
@@ -357,9 +369,16 @@ const (
 
 // Defines values for ListReservationsParamsStatus.
 const (
-	Active  ListReservationsParamsStatus = "active"
-	All     ListReservationsParamsStatus = "all"
-	Expired ListReservationsParamsStatus = "expired"
+	ListReservationsParamsStatusActive  ListReservationsParamsStatus = "active"
+	ListReservationsParamsStatusAll     ListReservationsParamsStatus = "all"
+	ListReservationsParamsStatusExpired ListReservationsParamsStatus = "expired"
+)
+
+// Defines values for ListTransactionsParamsStatus.
+const (
+	ListTransactionsParamsStatusActive    ListTransactionsParamsStatus = "active"
+	ListTransactionsParamsStatusAll       ListTransactionsParamsStatus = "all"
+	ListTransactionsParamsStatusCompleted ListTransactionsParamsStatus = "completed"
 )
 
 // Certificate A client certificate
@@ -1067,6 +1086,79 @@ type TokenCacheMode string
 // TokenType The type of token
 type TokenType string
 
+// TransactionDetail Detailed transaction information including meter values
+type TransactionDetail struct {
+	// IdTag The identifier used to start the transaction
+	IdTag string `json:"idTag"`
+
+	// MeterStart Meter value in Wh at start of transaction
+	MeterStart int `json:"meterStart"`
+
+	// MeterStop Meter value in Wh at end of transaction (null if active)
+	MeterStop *int `json:"meterStop,omitempty"`
+
+	// MeterValues All meter values recorded during the transaction
+	MeterValues []MeterValue `json:"meterValues"`
+
+	// StartTime ISO 8601 timestamp when the transaction started
+	StartTime time.Time `json:"startTime"`
+
+	// Status Status of the transaction
+	Status TransactionDetailStatus `json:"status"`
+
+	// StopTime ISO 8601 timestamp when the transaction stopped (null if active)
+	StopTime *time.Time `json:"stopTime,omitempty"`
+
+	// TokenType The type of token used
+	TokenType *string `json:"tokenType,omitempty"`
+
+	// TransactionId The transaction identifier
+	TransactionId string `json:"transactionId"`
+}
+
+// TransactionDetailStatus Status of the transaction
+type TransactionDetailStatus string
+
+// TransactionList List of transactions with pagination
+type TransactionList struct {
+	// Limit Maximum number of results returned
+	Limit int `json:"limit"`
+
+	// Offset Number of results skipped
+	Offset int `json:"offset"`
+
+	// Total Total number of transactions matching the filter
+	Total        int64                `json:"total"`
+	Transactions []TransactionSummary `json:"transactions"`
+}
+
+// TransactionSummary Summary of a transaction
+type TransactionSummary struct {
+	// IdTag The identifier used to start the transaction
+	IdTag string `json:"idTag"`
+
+	// MeterStart Meter value in Wh at start of transaction
+	MeterStart int `json:"meterStart"`
+
+	// MeterStop Meter value in Wh at end of transaction (null if active)
+	MeterStop *int `json:"meterStop,omitempty"`
+
+	// StartTime ISO 8601 timestamp when the transaction started
+	StartTime time.Time `json:"startTime"`
+
+	// Status Status of the transaction
+	Status TransactionSummaryStatus `json:"status"`
+
+	// StopTime ISO 8601 timestamp when the transaction stopped (null if active)
+	StopTime *time.Time `json:"stopTime,omitempty"`
+
+	// TransactionId The transaction identifier
+	TransactionId string `json:"transactionId"`
+}
+
+// TransactionSummaryStatus Status of the transaction
+type TransactionSummaryStatus string
+
 // UnlockConnectorRequest defines model for UnlockConnectorRequest.
 type UnlockConnectorRequest struct {
 	// ConnectorId ID of the connector to unlock
@@ -1274,6 +1366,27 @@ type ListReservationsParams struct {
 // ListReservationsParamsStatus defines parameters for ListReservations.
 type ListReservationsParamsStatus string
 
+// ListTransactionsParams defines parameters for ListTransactions.
+type ListTransactionsParams struct {
+	// Status Filter by transaction status (default: all)
+	Status *ListTransactionsParamsStatus `form:"status,omitempty" json:"status,omitempty"`
+
+	// Limit Maximum number of transactions to return (default: 50, max: 100)
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Offset Number of transactions to skip for pagination (default: 0)
+	Offset *int `form:"offset,omitempty" json:"offset,omitempty"`
+
+	// StartDate Filter transactions starting on or after this date (ISO8601)
+	StartDate *time.Time `form:"startDate,omitempty" json:"startDate,omitempty"`
+
+	// EndDate Filter transactions starting on or before this date (ISO8601)
+	EndDate *time.Time `form:"endDate,omitempty" json:"endDate,omitempty"`
+}
+
+// ListTransactionsParamsStatus defines parameters for ListTransactions.
+type ListTransactionsParamsStatus string
+
 // GetChargeStationVariablesParams defines parameters for GetChargeStationVariables.
 type GetChargeStationVariablesParams struct {
 	// Component Filter by component name
@@ -1462,6 +1575,12 @@ type ServerInterface interface {
 	// Request a charge station reset
 	// (POST /cs/{csId}/reset)
 	ResetChargeStation(w http.ResponseWriter, r *http.Request, csId string)
+	// Get transaction details
+	// (GET /cs/{csId}/transaction/{transactionId})
+	GetTransactionDetails(w http.ResponseWriter, r *http.Request, csId string, transactionId string)
+	// List transactions for a charge station
+	// (GET /cs/{csId}/transactions)
+	ListTransactions(w http.ResponseWriter, r *http.Request, csId string, params ListTransactionsParams)
 
 	// (POST /cs/{csId}/trigger)
 	TriggerChargeStation(w http.ResponseWriter, r *http.Request, csId string)
@@ -1702,6 +1821,18 @@ func (_ Unimplemented) ListReservations(w http.ResponseWriter, r *http.Request, 
 // Request a charge station reset
 // (POST /cs/{csId}/reset)
 func (_ Unimplemented) ResetChargeStation(w http.ResponseWriter, r *http.Request, csId string) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Get transaction details
+// (GET /cs/{csId}/transaction/{transactionId})
+func (_ Unimplemented) GetTransactionDetails(w http.ResponseWriter, r *http.Request, csId string, transactionId string) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// List transactions for a charge station
+// (GET /cs/{csId}/transactions)
+func (_ Unimplemented) ListTransactions(w http.ResponseWriter, r *http.Request, csId string, params ListTransactionsParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -2860,6 +2991,108 @@ func (siw *ServerInterfaceWrapper) ResetChargeStation(w http.ResponseWriter, r *
 	handler.ServeHTTP(w, r)
 }
 
+// GetTransactionDetails operation middleware
+func (siw *ServerInterfaceWrapper) GetTransactionDetails(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "csId" -------------
+	var csId string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "csId", chi.URLParam(r, "csId"), &csId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "csId", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "transactionId" -------------
+	var transactionId string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "transactionId", chi.URLParam(r, "transactionId"), &transactionId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "transactionId", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetTransactionDetails(w, r, csId, transactionId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListTransactions operation middleware
+func (siw *ServerInterfaceWrapper) ListTransactions(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "csId" -------------
+	var csId string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "csId", chi.URLParam(r, "csId"), &csId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "csId", Err: err})
+		return
+	}
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ListTransactionsParams
+
+	// ------------- Optional query parameter "status" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "status", r.URL.Query(), &params.Status)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "status", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "limit" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "limit", r.URL.Query(), &params.Limit)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "limit", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "offset" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "offset", r.URL.Query(), &params.Offset)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "offset", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "startDate" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "startDate", r.URL.Query(), &params.StartDate)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "startDate", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "endDate" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "endDate", r.URL.Query(), &params.EndDate)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "endDate", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListTransactions(w, r, csId, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // TriggerChargeStation operation middleware
 func (siw *ServerInterfaceWrapper) TriggerChargeStation(w http.ResponseWriter, r *http.Request) {
 
@@ -3311,6 +3544,12 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Post(options.BaseURL+"/cs/{csId}/reset", wrapper.ResetChargeStation)
 	})
 	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/cs/{csId}/transaction/{transactionId}", wrapper.GetTransactionDetails)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/cs/{csId}/transactions", wrapper.ListTransactions)
+	})
+	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/cs/{csId}/trigger", wrapper.TriggerChargeStation)
 	})
 	r.Group(func(r chi.Router) {
@@ -3344,182 +3583,190 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+x9+W/bvLLov0LoPeAkF8raBecLcHCfG6etb7M922lx30mR0hJt80YifUgqqU/R//2B",
-	"m0RJ1JLta9qvv7SxRJHD4cxwNg6/BRFNV5QgInhw8C3g0RKlUP15iJjAcxxBgeTPGPGI4ZXAlAQHwQBE",
-	"CUZEgMhpFQYrRlfyAVI9RG09TJcInB+dAEQiGqPY7QjcYrEEBN0mmCAOGFolMEIxmK3Bl8tL8iUIA7Fe",
-	"oeAg4IJhsgi+fw8Dhv6VYYbi4OCfpYE/543p7H9QJILvoTu195Avh1DAMfpXhriow+m0BUvIlyCGAoI5",
-	"ZQDHiAg8X2OyABDwFYpku74YsQPLx+VGcpRBsqAMi2XqQb19BTKOYiAoWCCCmIRPLDWMQRggkqUSFZP3",
-	"g/1Xr4NQ/vHi7y/1H6/29h28WCSGAeY8Q+wDWkvg6iPLp4DO1TC66d84WGWzBEfgGq2DMEjh12NEFmIZ",
-	"HOzt/71xhFOYojsMEWMuMFlkmC9RDAhMUZ+hOGIYJqdZOkOsfVl1S0B001LXL3e7aK28WrUZVpFagatO",
-	"nc2knFOMl6SXkCzQ4AbiBM5wgsW6kaLNC0k5kfpK/scWCHABZRNAGYgoISgSlAHodFmnZ9tsFOtx5jBL",
-	"RHCwG1bRnfc3GoKNXfAPIHmH5WOG4DLb3X2B5JuCk+xHm3JRMMGppOliRTARaIGYnD664cjC4I579HFy",
-	"JIeU/Hp2eH4O9rd3t/fABlUNYNLds35Sk14SYaKEHDUV5LDe2UpyJb6Rz0aE5r8+d5GUetuwyGyBJhpl",
-	"g0x4GMggWi5jjATECVdzh5U1rq3kDHL0+qWWFueQ81vKYr/Q1i2t3A7B5P1ga//Vay0cDetWCGplOyzx",
-	"1uuXPgFBbmCC4wuOmGT0QZLQW+SBZDQHHCkaFixTko8ASID5XIpG9T24xUkCCBVgxdCN3LA84Bk6kxDk",
-	"EM0oTRAkWpBEGcNifc7oHCcNW5ltBFa6lYQs40ghvz7kAfgP8GX3C9gCGVFfSkHOIOEryoTe/maQ4wjA",
-	"TCxl2z3Zdno88b3bL72r78uXJKgTdoXkqnPspL4R4QImiSNGeRNihKQKBx4ucYP194ASD3q2gfyy9Ila",
-	"x5nsjohLIpe9vo6Qr0m0ZJTQjCfr7UvStv+q31ig9F5w/0BdJwzkfLMmsNW7EBhRrGA+RyTWxG1F0yCK",
-	"0EogyZBjJNdX/Wnb+VQDKwZtDx/33wVhcHIm/3kbhMHh5GTSU7KFnfqZeQAZg+u2HZF30+kECcnYClsw",
-	"jrEW++eltatj8RqtAeaKxpQUMWKN6862wdvydpK340uaJTFYwhutjM2plF9SQVxBIRAjB5dEbXRRrnbr",
-	"fW9HP72BDMNZgvRDwwa2pR4iUlIuSrIYSYFnNzKnmSJREhmQIImB3B0Bji8JRysoNUVFXxyleCuiCSVc",
-	"j2RHbx8ob1UfBwrB8CyTIkeuCmgfLoVf5b4LErUfFFv03vZrifxXu7uKwWEkEOOam12lb3d310On5bW0",
-	"q9+0B7bTzpThxcKnPJoXtR4BjLyba01Ncjs7K1aw0JG2wdiQvAKd0xSBFHEOFwhIoDnYmChOP6WGGZQS",
-	"dYIEYh9hkiHeQ7Mppme5+g2lwu1Rmgu1YeRDvCAf998dlkwd+VDhD5OFwaCnAU1nmKC4/MaBOwiDIYYL",
-	"QrnAEfeO/haz9BYy5H35HkEmZgiKIAzUq/UYyV01/3lCCRZU0kv+4lzaMHzZ2u8xXXied0s8g+RGQYXJ",
-	"wlEsKnRTbqCpZ05ZCoVeyhf7gW9lK999wCR2V3kw4zTJFOLHKLEq6liqAKxJ/le6PM/YivLSjjD9aucR",
-	"BtOvQ73/FI80Z51TTMQJ/FrXM+pDTaIlijONl//N0Dw4CP7XTuGu2DG+ip3Danu1BHIyiETr6uSHECfS",
-	"kPmE0HWy9gLABYyuj9ENSrz47uIqSLiWA73XS+msbxlNS+1jKNCWwMrarcGoPpnSvh9U99AaYZVm3bjc",
-	"ftLyLFkPcj/G2jgtk7xRn8vaWZ/VN71+wmKZG5udukQ+Wg94yz1LdSJJzubBwT/vBF/wPfzWvjt00kt1",
-	"LZ3P69P47EzEZSi/oBlDgS4IFi7DfArCYNCLUc8RwzS+88pVPv+uOGyke9irLmAYxBnTsrcfb6U435TG",
-	"RjkvGIZms8ThFuMB0iKACRdfD2CyHKmNGGujvjpyy0uX4FSvV49Z6b/Ol5Drb5tF254PlQopBRx3EoxV",
-	"e9PpKjRz8GJBkg3HAnXT7kO2i7uyYKgc5fLriZzIfQnEGbXaY1+ZSskcLwxHaB+g4/frZ/CU+pCmz9aN",
-	"1MTACmLGCy9h0KltexyLpa5VtxxsWC1fqqjoK0xXetFyzW1EBGI3MAkOgte7uyX1cKJaOw329ncdKd+B",
-	"GL6ihCOfR1S/AXNGU6Bbl7FSgrlMfwxxaWjXez1HbEsakgYXtl1YSMdyR9do3WNxrP+7t1dgrMbNPXOl",
-	"/vKVbXcMjNGMUmEtEq1JT7KV1J5R3K0D69iAge/O9r7FWyf5N69vGYmstNrvkOi91CXkffAtl1RqlNuo",
-	"jaeejAQYgjEliaePT0sklki7Io1zQzbeUq19Tk8FrgcWpVULzcp+mtKr3YcicnC7aSIMMnJN6G071pkW",
-	"QCiWQHAgllAAyBAw37p4b3BwNfmcqgvfQIyFclheV7s5FFrV5Ozww9FU2kWDN8dH/mhc7AU0hV+vYLpC",
-	"DC5QXx0Ifr26oYno/8WK3iJ2VXX6DQ6v9q7O3w8mR1InPLx6kf8YHjZZUiSGrGSAHb4fDI+U4/Dw/eDs",
-	"v0by67OTo8l0dHg1cH+8cX8cuj+G7o8j98db98c798d790dp0P9yf3xwfxwHYfDuzfRqcGj+GMo/RkeH",
-	"V693X+z+cbV/xTFZJOhq73XluVgy1PhY4bz++PVL+3h/74/XV9O9ys+rw7OTN2flh/uVn742LwaV33IS",
-	"p0cng6tXV/u79u/XVy+cv1/lf+/tOi/2dt03L903L/Wb88Hp9OzdeHD+/urN2XR6dnJ1cV5+PD07vxqe",
-	"fToNwmB6NDkeXI3zvyZBGFycfjiVbzt3FUPFik8qXFGm+BI1OzTp4+EhFHAqLfg5Yn0CqByRGNwgElO2",
-	"lcctVYaAVoLaQm6xif5XwvtshgWDbA30vHVvG3q2IEZzTLQ/VY+66dsHjKew1dtovYkmiwEjlseqNPwG",
-	"C2Wv6yufz1VD4hvto3rjjrFRQdZmuf/9V6+61j0frXv9+ul7penaPaTnauU96awQ2Z0nMOWbdG/9TXsd",
-	"7V5bXZt2xe1Cb3wnOT3kjz7Wsejgu47XwiXbhy2yVUJhDOLiK42bDo5IaJSb9uW+L8YjcLtEDJX6NOGW",
-	"GTIDqjnnu1vGcIV49/a9SpNgXrtIp2hovUI1AXhuZzaHOOG6d2Mw73Y5BmUn68JyqQW0zRuACeAooiTm",
-	"YIbELUJEjb8GUAiUrpQF0T6SMq6n0gJtZn/VBkgzVbG9i9WIJolJIVhZC72fU5ILuuoYV8rLRx21Ih1y",
-	"EvrcTsWTBm6zCq4Lmllzw6BVop3jBJ1C36RPndBhiRVwgsAMSeHu0G0Nmwnk4mIV+yPKOEVcwHRl+5eN",
-	"DYQg0x/1X7X7o8KKn1GsPE4XxXT0n28hTpyf/uhC3TfUZCgOMV8lcG3kWV3PRiQeQoH8NPhpiXSygd36",
-	"jPiQVGuWI9b9o7icIdQPj9izAV4Q/K8MeTbbTiZOizm2ebMMKg4pEYgoHK0YpgyLdc8vz03zI7mSVnjc",
-	"B4lSnjwCFnUWVT/YJRMjC3gt8FKRQCRZS2Bvc8jjTOlXYok5cD6uJIcV28eL112UqzTRHP/FGvpI+eiG",
-	"+5yZ1oa8QwCkOdqh8+KuNGGSLEngLEHBgWAZ8mA+aybgZF2Qrk6LUIl1t1gssSaHw/MzDlYJFHKVwQYk",
-	"8SXh2UxnvVGWv+Kb250yPMNx4S8KXZz4EFmO2jaLsblpZ6UknXdnxekgoviIGPeqJaZviR6dF4TiYpwb",
-	"89UPFO0rndHTCL95YfmW3hItv3eK6WwopUeOIjWTFaMLhjjfvM9GkmPG9Ne0iwxzOJwf+U5iH+iMJpOH",
-	"ppYvb2Iellr0cVS27DyWyvSq9dOB1SQrpoDFwb10X5VSZJEYQbluzqKBjffT6fmO/Gey83Z6vvnkyrAd",
-	"W6vDYMMknR2A3c2768YY3aChlyMKpdWEQowKKe1vrca6eLFAbYPR3GR+0husUlVzeNVnHOA0RTGGAikn",
-	"aD+WejQ1voaudp0eLwgUGfOg500pIRfkLa38yDGjMonwgqDYECf3cjFeEEwWrcc/mpIZ7YkE2Udp7Ifp",
-	"7e8QPXbYo8I4UGCRxcjrLE0oWTS9rUJg+3G/8kEziqdwMSJz6nHeZGJJGf635nVMNEkpvqcMQAJGQyDg",
-	"osb86OsKs7Wf+ocqS9SqXboDoD5Q6+el2s69fgWlRFYz8ayuemmHkpAvGM1WKuE4n13Fb7PbY9Cm/aGM",
-	"tdqu4Lg23iQ0ulZ/HSkEaGGvcmEC5YA3G/b064OEvSS2pATVERHME3iYKPcvQPItMJqQpOSkjCuQYI9H",
-	"CfuxP11W7YQymj12h0OPbZpiQbh1xXWqqLLoqh9ajjEXPdxsESUCYqK1bZ3RmiBxB1TJh41KjEqStXEp",
-	"o9CQfLvqWJIesZDEO22f55bBtVIrSwNJ4sCoFPRrW6Qm2usKUbkoaoS5cVWPi6/vvp4avRIAR+d9NgvY",
-	"gqcmdPj1sEFVl8v3rOpsYRxLJdm7I0XGNK+/oJTFmNijCW004u6H6svMiidPr+rdldyrvQ2khdjf2FRW",
-	"6/dGWZ/bncQ4xPpsRNeYLOqhxuOz03dXJ2fTs/GnwX+rCNL4w+j03dW7wXjw7sh5cHw2DcLg7PRqOB59",
-	"PNKNz06vJtPxkQqwXpwOj8bvxmcXp0P78ed+O6RYXzXEYFdU2hQ5Ujs6q1CgpQ5DC8X6VVarTBIORH6y",
-	"XdzBMZ/Qhdcjb5If1KmGTY+JsvCqX4iL3Ght0d51S6W6a/tWahYJXTgSsp8KTpO455C65SMMyVBKBTru",
-	"YaMp1D5CYKKWBVMCwEcCCV1M/YcV1ytlDMiJCwqsseWoWI5j/JhKRWBizoPJX5+9+FAkNWp2eZoWSouk",
-	"QDAYXWtXm4SiCLI12YK/TjymZujoVXJxqNauia27/FoSn+0Rij/L29RCFOOCGiDnNMLqVJA6+6aIIofc",
-	"G8268/y9YQntDvKGKDJlob6BsY0slFPczEletdOfI5ZiLtWHISL4gV6livfe5w62L+oqk/Vjm0aAMnAx",
-	"HvXx8hTpSD2c7G9VY+tlTyBZZCYuUUnCMm+A3LzABtpebIfgb4j8Tf7L5b8x+lvFpf53xTq5ddMjYVah",
-	"I59BC04dsGugnlQwp3s7uCT/Ab4MJoej0RewBc4TKC069FWo5++nJ8fy8RhHS/XUfCUwWagGF2P12cX4",
-	"WAo8EwMBGziFCxSCWzRbwQXaVMfYciVHjhWEgexb0uN45BW2vkhN3U1gBrRUYcMQelanEtbkcB0lSE2C",
-	"ivzsKVWJgeYzrlqPyFtGiZAtJ0t6C2ZoThnSLbkUiIxqfUFjLLmFa55/oX+CG8zxLEEhWOLFUrK+BaiE",
-	"AQcuZcqrXoIwcPpsQ0kRAKqLB5M+rY/lawdKJWY1Q0WoSqPJfiTnMdThIRgJfGPcuKo7pJhfNX8Ls0Sg",
-	"WLZWcTGrRS0hB5AAxBhlGqGxxrtqZYoGJAjMMqE8lJiAjCNNRSR/nX9AM5XdyBG7wREq4c8CHISBAUai",
-	"0Ui9oqsGHNqsap+tY84/p7KRzdyGwi10kmtVdzvvWCoFYVOOGLLy+aG1Hfx7iEobj5smaw1308xMt6/F",
-	"7hxenLjjeMJxollnrW3EGvMFYvrtwR1R0KkT5xwNVXBHmhU6GOZ8u9npsHVXv4Rev0zOUdTsXjiHC2Xr",
-	"xNqVUCE+j0vBHHypyHZzqpg42qJKIJdaW8aIm2tRCrcXJ1CbCcQBCDAUURbfg0p8hEHnc45Eu86rZ8Gv",
-	"8WrVMAlBhU+VncrHDkJSKKKllGXFFDqU1rR0PlcPY4/t5MB3LPyknQeBTqUt86CUjLDGCR4d6avX7FUf",
-	"ANPAqiQajm19+AhHIXB4YvsNWmDiDW4WOlMlhKrgNOmZG2N4K/WwiYqyDKGA3r6aY33WwNPEBnnGUCo1",
-	"lI1DqDbTo48hGJEEiRCcZUL9/4bG64YsUPk9JHGzRVgaQqPniCC2WG8P1La3PUqlBrw9RgvMBWIhOKe3",
-	"iJXfegdfLaGXx+VjO2wMNo73QnC8H4LjFyE4DcHx3pb8d1/9+2JLP1Hv97dkk+MXW8d73vEy4hMGFwSL",
-	"2jw/LUNwLf+5gUz+qf/7JB+G4OMgBNfynxvI9LsQDELwMQQfQnCIEo4zHoK3cMkQWSIsQnCOWISIHwsN",
-	"pyhO7Pw1kW+QLEUMRwByk/TbLX5vGmVtbqz0yX+lrFQ1BVD7cV3e5q9ajP5qMrG0+q2XOP++Zux1R4hG",
-	"BAsME18fVhMqipzk8aJ+qa2atlkDQw5VwrXOecEGishfY0k2OTs8HwHm9AhWjEba21dGZ3cRF6sIlLoz",
-	"NrYKbuuX2rDGHKSQXaNYEtGX8dG70WR6ND4aftGlkWRTQa8RyQvpQF1ZCQh6SWZF5BZGElr5FiASrygm",
-	"ggN4Q3Fs15EgU5Sidb7tAF6SL+dHp8PR6Ts/fJQk6zKQFjDZ8MsOjVZ4x4QK+JfQPtnf3v+iCpEUv3ci",
-	"hhRRwoR/uST5nLZLarQBJgiDAnP+MjgSRv+iafCdsk8RTdOMqEoRZGF9HQigk8k52DgcHw2PTqejwfHk",
-	"anr24ej0aqAyo7rqY2Us8Q8v7U5DMGoEi518GdWK2FwInbM1OZlofMNIyGXRNW5IXARe8l4s3dX9mB1q",
-	"okLYZy/fSYOmJZ5WnOrKG3Lf6cviZd8ohjN0LiR7HEMsBuqYT6/SewxJuxQ6ZV+cIe5mUukyQY5Zpby8",
-	"sjPUL8TZln8wmpyBv7/e3XO86Hk2ggNxV0qCP2zdFf5WjHS7VD6X+rkKaWcXU3Vx2SNs3poCkUcQdCtg",
-	"A+RdnToIucM2uVTHMd3Ff0gRiNJyhnlsvwxaJwW36A75kpvd72HE2o9CNbvEA3F/Ar2F3HBd/xMNPw1j",
-	"5AjNScl/qOBeVP/jyLzb/V/VldzuPRlEhZfsLIqyFa6fmCqcZmFwCEmEkqSUcfS5O1TnIifsw5stIQLJ",
-	"b8LZUMqcJloDfhIStdmsEJOodusC07k03d+XD0LetSDpBIlKfZtGSLtKbLQH6yJeGeeudYE6JKan/4b5",
-	"lo+gNE635/GNyoGWut+l+QBBU1zw/XR63hQJVB5pv2hRrxyJfo+qk8B98YCo2NSvZA9IJQNI65a1zQdG",
-	"S3RiMjOqZmRsy4kuoVCF9JTgUJq7/E4q6phbs8OVIMefBv89kcbl8fHZp6Nh8dfV2du3x6PTI3UQ+uPR",
-	"2F8piRJpC4uW/VC9Vz5ZdDIYDTc9cVJrY2zouE298qOpt0iZys83JSeDg2Djn4Ot/we3/v352/73zY2t",
-	"/9wsHrwoP9jd+uPztz/qzzb/Mwgbk4sOvcjW81INdEjQKest8SytlIpG1RENDAOVh+pHIuYAxzpRlStN",
-	"MFslxeoqPTGF1wiIWwooAyllyL66pexamj+UoM4TP7aet4e4zLzkckCyDkFKeV52RakItXqipilYMSnq",
-	"YlsMd/x2NAQRZHGookMEScsXMpysc/POf6hEB2Cbl2PF0BwxhmJg21p71SZzQw6kWvP6xR9be0Ujk450",
-	"p6Uqkg4aaD62Feu1F1qpZyr5QGcdxGADLwhlGi1ab9vRr/ofJlMpU01Mp15KoukkzBel2b5oKY/rcQu4",
-	"QsaVKMOr92eHVxeTo7EUJufn9s+z6Xv1v6QCrzDxntOSQ2Va7dJCAsc9aFlnTntI2ZyKUz3Z9GpPkRjM",
-	"s+YS+6qkrGqxwxCMdWVZ1XbHaoaR9Rnl9A9JQf49CmgV8qdY7NCWGdbnyBzZmzOvnXno7Ba+neiCJDS6",
-	"ziOWfZWbCjaHTqEco6VLtlN9P7S+XxhoJsuzeO9wNOlO2eqdGbwE3VazdzfSjAswQ2Ch2FeaAJDYVN/N",
-	"R86+9iVdK8dhHO/kiUwPTcHuynvVA7Wn4Rnsb7zNkuQfpuC3vQ5BYjkEQzyfI6a9lv+wh+Vs2N1MbdOR",
-	"JbInVTe3+KxbqS8njDuA+4jsoyn6zGs15lpKo4iiVnSp9FtDeqltzH1BNvPKdNxcQSsvQd0QZ9ThurwX",
-	"j0pjyMFzuLz9xG57rkPpREedynFTfkPrd75whq3K7QOmWiHchwDiLWVwWCpC3imYVSMfHdk1ruOxGe6P",
-	"1YLj/cH+6FY0vy/UNXlsKcSZTlglvDuXuSuovxf/9SttM0GiYJ1W5mutYpizcd9ShjkyJr2KElb671vW",
-	"5tBZCVvWplgQN4FzYOExqbeVgoaf7yYILK09Og88qOM7kunkCcox5rTWTJ8FOdbKMPak1JZtwkaM8ia5",
-	"5YyZJ6mrKsh/S/7fkr8B6lyAtIyUs1YrkamZiPYKncUVGxzkX/gMsDQT9mqufh2aogFazroOrjGC8Zku",
-	"BvqJYYHM3/Kx+u2VkSupPnJ/hrp3ePMBBzBilEsZIOUwv0sF0o8llTLoleLRUdvTKyjrK/+oW/p3xbD6",
-	"zK46Thnp8qApxElwEKQQ3aAtgWD6f8SSZouluKXsmm9HNA0syQcn8OgjArJRvRazOr5CYAIG5yN9b5FA",
-	"ysOY+xL114eTk0kI0FfTWt8elR9gyrhO8dhW2X4RMiLdjD9YSeNZymmd2yqSAip1H1AY2POgB8Hu9q5u",
-	"R1eIwBUODoIX6pFyVC4Vd+xUblFaUZ+NoY9tKCdf7a4rYG6GksPrW2ZUkoMkezkXUb5WSpmHmVhKQatv",
-	"yvIEmTOOyQKkmchgoq/ZskE++aNImFKVZnUhFTqfm5IccgAg/96awURKMKYTT0rJVGZG5StRTMLFGxqv",
-	"KydB4GqVGM/Jzv9wbY5r07UzJuKM8L1MrdKc1YE9tSmr5djf3fPsByaCqijOXPf3SOAZlURBVg0ooq8r",
-	"pf3pOIViNZ6lKWTrHH+SIEoTDEsEtfOtcpfidz25BHmrLqjnTUS2hEIlH8wQIvkRP5f2DNXAym15pcvy",
-	"LolRf4dHYzBbC8R9tKEBKdPGCjKokmK5un4CS4AlExWioTLVoLrUobMk7SlH3z/XqOKlJ0+Z2sM0kjBe",
-	"6iZPTBSnVIA5zcjzokW9XlVaDIOFL737mNLrbPXjiUzD8ayIbPfppF7zTbA2/PkXp+GCLGvylO98i/go",
-	"/t68PdtccSk7Cbr1Xu3I11yg1OQecp6lhtzr2+8lkSxAqABrJDQrqBxGqVWgWCV7ql60F9WzfWOi9mBT",
-	"CU2fBrsknAIsjDaMSF7BHsV6d8dC5UHKKUgFVY6fRyt8/GPnXLo+rs5DngBpBVjX5vNxHM+vCqmxlecS",
-	"ZM1WT6BH1O6h/ZW0CbuYXvqtsMEONLfwesX7WJ040nFfmylukQRm60KQL6BAt3CtDo5KckkxQWBJb/so",
-	"qM3ivLZKz4Qgn0rO+6nScyzUubAxE8vcE/XniX3jrazR1rPigoJ2HRJ00z6rrODeFN64PWgHNi8fCdEF",
-	"qRuqcgLKPHeCb1+SC3NmQcBrBCRbrdQBn/JxWZV6mEJp/xJ1W6n6eY2kjC9O4sIFxFKyG48xBzMqlsV1",
-	"pHKbKXySvh2gfv/6Ly3+G+6a77UN7HuCt8bND7bKV6rn8QYdVeTZLMXiue0Xh95L9EvcUOEUlXSwEyUI",
-	"sjY9Sk2a+5QaQYH6GmDBvSF8NcI2uCQ6Mv9VVN5bjCrd6V8ZYmvHbXJ/JpAwlQLnhxKOZ7nvtFOhwp/B",
-	"8TOnPgWjZ/UBJR26S+3Ocr8rpIMQY2vwFjLasajyhVQKjyRXaZWqayy0BOeapmpuDn2wI6U3da9dwzUb",
-	"Ld4TVzNotXJ/GRFdNs2HUMC7y+hHgaR+HNVD4zZtBBoODLVgMqTlrn35jv9n7/lpotUWVuSN5sT/zRCz",
-	"9derZaUpc0qQu71tg4LJ3iGRV8N2KGQU80viFAYrTSBnV32m0enZJnKVqp+bFNZuzmyAhT8Dngwbz8XM",
-	"cSINw9m67KnTSQVqZLWXel1kJvWggMKG3j7uvxtTKio3op/Vn8nduf60fA/74RJiiewTSLI5jETGEKt+",
-	"87n3/vjDJYBWTaqq1fOVAe+QaODDZkkQ5gpgmUMMezRtXvwv4l+yaHBn3msP2/UccPvwrKjFTK1MJ14J",
-	"WtsvzGmlLXODubNn1MRs7WRTL9++poRmh75HaHoFYO2OY0NYrRUTG/pqupS+LlOnX+25rzCYfh3qBS8e",
-	"aQI7p5iIE5g3/Rz2nVXprvyek3py11flan0POea309piZvn99789X2UZ7sWQ306fIMGtz8r5QtdW8Tiu",
-	"GlUk5c5SdzSkkBUghCp/AOj8AfVbGuLxmsAUR2DFsHzo07DqhzOfhvOfaBNoPlv6CF6m2mpZI/9fGcq0",
-	"hf+bHww/TDz80LUf7Xwzf5hQYeFb8HiM/hQqDb3d5FC2B6/vs1n93vgaN74O3lQerd+M2dP118mackSO",
-	"Bdqy1ye1Kou29cQ2/nHa4uMyZJzlNZyLjvK1fPF6160Yvnd35hxDgS6IKojo6T8YOMm2n4IwGPQzwx9R",
-	"R6ytrC88ahvld2395riqauhBUZXjdDZJXlKuKTlAeduMP8+UMyl9642G6qSvPCqjeNb5ZvuSWHdVsnYc",
-	"Vq4i6oxwjda8wT1XdjyU5vRknodeCWS9fHaHNE3hlqmI4NSUrU+/cieCj8ev0TroVIGfjG8dgNtcaKWG",
-	"v5MaWk27gjDL9LBh+WpTlw8Q0bI5haH8qTniSkkny+rvq1xrEy72d/dBrg2pbP0VYlvXaG2P3W2DCU3t",
-	"GQ4OUri2SUUAmhMVzRkKPxVTP5V70Z12+UDznxwc80LSzOGuklyiPZMnoQuUit9qco/8jGa+L2/mMRRw",
-	"S1VGn6OWbI2JShe9QSSmbCvfa1XcTOWf+rJgbVQthUL5dDhKIRE44pdEXWSqSs/miYK67wdkZ0z07ehw",
-	"aifzy8YP3Fn+IM4ug9CLpTWxmG+eedaJpKUKwIJ2xCzi4pKpZj4aGRHGAQTOB/k9TzaIZlgMxf4bzCQn",
-	"b+vsp8p7FVaMaJKgSJRGkAxkRhFLlNqDFnnFXFu03Z//rRartLk6d2r9dbZWZ9KP6K11lymvJ/189rpK",
-	"3qyGz4XZc9NeC3PsFJX2OrPKrdnoYRWTUGsrdTcxTB/jz1nVSV5Y8DkS9BOZYPX5e6jDaWRx/3xssJoV",
-	"1EgwdcJUFSq3nIKWbRoQzC9ZErR0wZI/7AV4xBBSKd7HR0Pb2k3EttdGhdbdokJg6hjP1gxyFNuPdFws",
-	"zRKBV0n1bi++fUkK7UjVl28ImVUqcv6yOlJjKdNHkNeWBJ6X7x7Ye6LyKmVUqlemRMyzC7nFlQvdOtN5",
-	"K5y68838UQvBVbeTlN4ofSs3W+yQDSlLDpv24CkVpXh2XBW23ajoFK62mfb+UXMMP3U07DcnPShGVuWl",
-	"XgpZiZva1DEnPT73Muepsc7R0goUvCWR3e/CVzcZUpbvif0Y8F1V0j/LHNu3epo5bmZr585FYao3+iPS",
-	"ohwK73GnaXFvZD9ILMIbYHBe3wmM0o2edxcNCyR+C4aHhAL8DNkuF+aYpbeQoftYafZbWwK0p4kWXhJM",
-	"oiTTt9mZvgyGw/xku0X5Bp4DSNabofFoqJFWjC4Y4r1CfW8NlE9t6j0L064yWQ8d2RbPz6h7Ztzkp+5G",
-	"/snyG8m7PYHVro0t2ejTqDjJGVpkCWSXRHnZ1d2M1S65dsn7nIUxvSW6vhCJbXK/Gt52cUnyjbyXt1BX",
-	"bPby3K9rb9oZ6sk/orFZpY2SY/DZMMiU4cUCMR8lt+836nTvVmJqXndvNTRdqWNoTYW97+sQPPbX4f61",
-	"dwf/pNviOcdNaH8u24ZU0Qg15KHI6rntI40l6RtT8LVM4a0F7Tv3jGrxh3mWJMCUZ1d1JVTavVNiPd85",
-	"GkX88+aZx5fxDVcRPIKQLy5+/Z0H7Cl/qLaSZr5p2lF2booLHXobMZU7Hkx5uabBLwkX9hKX3geDcwoq",
-	"7if45XcZZ7rd+4sSaHYhfu8sD91ZLCrrnLLomaqQ0MVdUxS0005R+2Kzb1LBsYToL5NNcEwXj7iHyDX6",
-	"WbIHqvTUZSMs7pU14IzyiNkCx3TxbLMEmpy9boK8pRF1Na3P3WsaVDaQP/XAb4Fj7x6x+AkyEGrEV6Vq",
-	"RTdb5tqG7lMUSyw1DSwlvPoyv3MIEcQWKhDDs1R9F4IVvUUsBDc0EXCBQoBEtL0JLglD2lVtky4b/Uo6",
-	"KqPK75IYrOACkzYGOZEQfbQ3UDzX4MtsXb2Z+TFPNjYNqTIIYaRm2jio08jPd71YXEAm1F2MYMPe3rzZ",
-	"HFdiYqrvFSwG63PtYBsEiMQ9x0ckfqTRT+BXuS6Owm4OEpiDLxkjDTAkOG06z7anjsvpntWvHqfnKqWP",
-	"feDwa7wCGwU7NWGHzuf6Ai8PaLvhjyvE4PB5mxZ/4gooe/YoBjyLIsT5PEt0WZvfFq6zX5SEeg+liKE8",
-	"9N6StJbJySCuK/2WjgSogtTmHowZAmrWRf31ej4/5gCrStWXRBUbNcXaZwhkXN+sCsFC7kUwqcr3vKK1",
-	"umkCRUtIME9DgIXs0vZ2SeaqeoS+TTY//5MXFI4ztR8JxAUmi20wmAuVR16aVuitsa3iHDNkTg9JStSz",
-	"rGMlgsTUW53PUSQAnquQCMvU2gnqN2TylfgrFsieICEX5JepWuQsZ49KRe6N/M1FgVUZcK7Or+XN715B",
-	"pSmCN0NlIjWjoMqlrDcY6uyFsX59Sm+9CW0K2LEzr7+MQe5M+hENc3fNGwz03T+B7N/A2A7/e/N1U+gU",
-	"vas71S2nuEzdzO8735wfHVmoh5BEKOEAEiC1/BtUoooHM3ykujfXjRf95hyvh3fI28v41UY/g4NjWply",
-	"FwClJWuFpPPy5ntUXZYITlolwY/1b5cI/znxqKZv2JMzm/0px+p6PrdpH5/gmzUwqDAGJfdwMW/MUDVB",
-	"9QK6n8px6HKXcbttGGwcGDS0OBm0n9RXMUZ/6pSNKR58XalJhAFMkj+7joyzUF11BksU93tLdS5YMhkh",
-	"DnbqvCpcfblqUfGK0/2nKu2nwH+oAqk6yXcJWzfYURer0bobmOCShvfK385chalMANZgAZlBq1JIL1tl",
-	"LYVO/WpeTZMb9le0jc3Uf2bTuLLaGUlodL2V68rNy36hWuYXRf9UHFyB/aG8rLv7scwsKNBrV7J0POV8",
-	"qvxdupC8I0hV3EyuPJhtlYLy/ID8XvSmc0H5+gBI4h3KivuWJdX0CdnmQ/xcmldUvZvcH64q7ne+V9To",
-	"pnKVuG8Q5+LoH1MlrH71vkd61S/f/62VtVcHK/jVSdppqw2mqkHflO4o76wJpjl9Uub09nJg+Qi2JlhL",
-	"/eefgcmfaJvKp/xDq3zVoOhVDqi4s/93ca8exam7eVbu2vZYzs43+1fvu2ztB8UN+uq2tJbbYI/NF334",
-	"Le+9i9MKuIO73q/8FAl6kVWJfr37X5sXXdMSM+16kQ+Ron4EVpCJdYWCwBDZM5zWz10KueZnyvLrYm9x",
-	"klwShMUSsVwuKOefHI9VINZjGieeBSBJwC3ExWkg/VzQortL0tRhF92fy76Cp3IdFBD9qlTXTCua8AS9",
-	"RqTDg6vOKMp2XCcy6KuudSqCuVSYMvxvlCsmDW7ZqeqjwTbtTsq5T6HuetaRm2fUkWb0UB0bC5TyrkVW",
-	"SJHUY4aHjMF1myNUr8Tzc0GWU+ELKNuj9JTZo08A6o/uT2MTpEnsicSFWalfSE5omMzpaRUura+hIyZ2",
-	"vqn/LrBWc/wSw173/8C11P3Y5ex2ZlnI+hoOL17/uZEOh3gqWnod5cWl2H+Wcn5K5e6dkedFnpaWmuhS",
-	"Nla+uDZFOAExukEJ1fd56/ZBGGQsCQ6CpRCrgx19im1JuTj44+Xe7g5c4Z2b3eD75+//PwAA//8iDeph",
-	"0/wAAA==",
+	"H4sIAAAAAAAC/+x9+XPbOpPgv4LibtVnT9Fnjvqeq6ZmFctJNM/XWkpSs59TDkRCEsYUoAeAdjSp/O9b",
+	"OAmS4OEjiZOXXxKLBIFGo7vRFxpfooQuV5QgInh08CXiyQItofrzEDGBZziBAsmfKeIJwyuBKYkOogFI",
+	"MoyIAInXKo5WjK7kA6R6SNp6mCwQOD86AYgkNEWp3xG4xWIBCLrNMEEcMLTKYIJSMF2DT5eX5FMUR2K9",
+	"QtFBxAXDZB59/RpHDP2VY4bS6OBfpYE/usZ0+t8oEdHX2J/aW8gXQyjgBforR1zU4fTaggXkC5BCAcGM",
+	"MoBTRASerTGZAwj4CiWyXV+M2IHl43IjOcogm1OGxWIZQL19BXKOUiAomCOCmIRPLDSMURwhki8lKsZv",
+	"B/svXkax/OPZP5/rP17s7Xt4sUiMI8x5jtifaC2Bq48snwI6U8Popv/gYJVPM5yAa7SO4mgJPx8jMheL",
+	"6GBv/5+NI5zCJbrDECnmApN5jvkCpYDAJeozFEcMw+w0X04Ra19W3RIQ3bTU9fPdLlorr1ZthlWkVuCq",
+	"U2czKTuKCZL0ApI5GtxAnMEpzrBYN1K0eSEpJ1Ffyf/YHAEuoGwCKAMJJQQlgjIAvS7r9GybjVI9zgzm",
+	"mYgOduMqul1/oyHY2AX/DiTvMDdmDC7z3d1nSL4pOMl+tCkXBRO8lDRdrAgmAs0Rk9NHNxxZGPxxj96P",
+	"j+SQkl/PDs/Pwf727vYe2KCqAcy6e9ZPatJLIkyUkKOmgjzWO1tJrsQ38tmIUPfrYxdJqbcNi8zmaKxR",
+	"NshFgIEMouUypkhAnHE1d1hZ49pKTiFHL59raXEOOb+lLA0Lbd3Syu0YjN8OtvZfvNTC0bBuhaBWtsMS",
+	"b718HhIQ5AZmOH3HEZOMPsgyeosCkIxmgCNFw4LlSvIRAAkwn0vRqL4HtzjLAKECrBi6kRtWADxDZxIC",
+	"B9GU0gxBogVJkjMs1ueMznDWsJXZRmClW0nIco4U8utDHoB/A592P4EtkBP1pRTkDBK+okzo7W8KOU4A",
+	"zMVCtt2TbSfH49C7/dK7+r58SaI6YVdIrjrHTuobES5glnlilDchRkiq8ODhEjdYfw8oCaBnG8gvS5+o",
+	"dZzK7oi4JHLZ6+sI+ZokC0YJzXm23r4kbfuv+o0FWt4L7h+o68SRnG/eBLZ6FwMjihXM54ikmritaBok",
+	"CVoJJBnyAsn1VX/adiHVwIpB28P7/TdRHJ2cyX9eR3F0OD4Z95Rscad+Zh5AxuC6bUfk3XQ6RkIytsIW",
+	"TFOsxf55ae3qWLxGa4C5ojElRYxY47qzbfC6vJ24dnxB8ywFC3ijlbEZlfJLKogrKARi5OCSqI0ucWq3",
+	"3vd29NMbyDCcZkg/NGxgW+ohEiXlkixPkRR4diPzmikSJYkBCZIUyN0R4PSScLSCUlNU9MXREm8lNKOE",
+	"65Hs6O0DuVb1caAQDE9zKXLkqoD24Zbws9x3Qab2g2KL3tt+KZH/YndXMThMBGJcc7Ov9O3u7gbotLyW",
+	"dvWb9sB22pkwPJ+HlEfzotYjgElwc62pSX5nZ8UKFjrSNrgwJK9A53SJwBJxDucISKA52BgrTj+lhhmU",
+	"EnWCBGLvYZYj3kOzKaZnufoVpcLvUZoLtWHkQzwn7/ffHJZMHflQ4Q+TucFgoAFdTjFBafmNB3cUR0MM",
+	"54RygRMeHP01ZstbyFDw5VsEmZgiKKI4Uq/WF0juqu7nCSVYUEkv7sW5tGH4orXfYzoPPO+WeAbJjYIK",
+	"k7mnWFToptxAU8+MsiUUeimf7Uehla189ycmqb/KgymnWa4Qf4Eyq6JeSBWANcn/SpfnOVtRXtoRJp/t",
+	"POJo8nmo95/ikeasc4qJOIGf63pGfahxskBprvHyvxmaRQfR/9op3BU7xlexc1htr5ZATgaRZF2d/BDi",
+	"TBoyHxC6ztZBALiAyfUxukFZEN9dXAUJ13Kg93opnfU1o8tS+xQKtCWwsnZrMKpPJrTvB9U9tEZYpVk3",
+	"LneYtAJL1oPcj7E2Tsskb9TnsnbWZ/VNrx+wWDhjs1OXcKP1gLfcs1QnsuxsFh38607wRV/jL+27Qye9",
+	"VNfS+7w+jY/eRHyGCguaCyjQO4KFzzAfojga9GLUc8QwTe+8cpXPvyoOG+ke9qoLGEdpzrTs7cdbS+w2",
+	"pQujnBcMQ/Np5nGL8QBpEcCEj68HMJlDaiPG2qivjtzy0mV4qderx6z0X+cLyPW3zaJtL4RKhZQCjjsJ",
+	"xqq96XUVmzkEsSDJhmOBumn3IdvFXVkwVo5y+fVYTuS+BOKNWu2xr0ylZIbnhiO0D9Dz+/UzeEp9SNNn",
+	"60ZqYmAFMeOFlzDq1LYDjsVS16pbDjasli9VVPQZLld60ZzmNiICsRuYRQfRy93dkno4Vq29Bnv7u56U",
+	"70AMX1HCUcgjqt+AGaNLoFuXsVKCuUx/DHFpaNd7PUdsSxqSBhe2XVxIx3JH12jdY3Gs/7u3V+BCjes8",
+	"c6X+3Mq2OwYu0JRSYS0SrUmP85XUnlHarQPr2ICB7872vsVbJ/k3r28Ziay02m+Q6L3UJeT9GVouqdQo",
+	"t1EbT30zEmAIppRkgT4+LJBYIO2KNM4N2XhLtQ45PRW4AViUVi00K4dpSq92H4pw4HbTRBzl5JrQ23as",
+	"My2AUCqB4EAsoACQIWC+9fHe4OBq8jlVF76BGAvlsLyudnMotKrx2eGfRxNpFw1eHR+Fo3FpENAl/HwF",
+	"lyvE4Bz11YHg56sbmon+X6zoLWJXVaff4PBq7+r87WB8JHXCw6tn7sfwsMmSIilkJQPs8O1geKQch4dv",
+	"B2f/OZJfn50cjSejw6uB/+OV/+PQ/zH0fxz5P177P974P976P0qD/qf/40//x3EUR29eTa4Gh+aPofxj",
+	"dHR49XL32e4fV/tXHJN5hq72XlaeiwVDjY8VzuuPXz63j/f3/nh5Ndmr/Lw6PDt5dVZ+uF/5GWrzbFD5",
+	"LSdxenQyuHpxtb9r/3559cz7+4X7e2/Xe7G367957r95rt+cD04nZ28uBudvr16dTSZnJ1fvzsuPJ2fn",
+	"V8OzD6dRHE2OxseDqwv31ziKo3enf57Kt527iqFixScVrihTfImaPZoM8fAQCjiRFvwMsT4BVI5ICm4Q",
+	"SSnbcnFLlSGglaC2kFtqov+V8D6bYsEgWwM9b93bhp4tSNEME+1P1aNuhvYB4yls9TZab6LJYsCIuViV",
+	"ht9goex1fRHyuWpIQqO9V2/8MTYqyNos97//4kXXurvRutevn75Xmq7dQ3qulutJZ4XI7gKBqdCke+tv",
+	"2uto99rq2rQrbu/0xnfi6ME9el/HoofvOl4Ll2wftshXGYUpSIuvNG46OCKjiTPty32/uxiB2wViqNSn",
+	"CbdMkRlQzdntbjnDFeLd2w8qTYIF7SKdoqH1CtUE4Jmd2QzijOvejcG82+UYlJ2sC8ulFtA2bwAmgKOE",
+	"kpSDKRK3CBE1/hpAIdBypSyI9pGUcT2RFmgz+6s2QJqpiu19rCY0y0wKwcpa6P2cklzQVce4Ul4+6qgV",
+	"6eBI6GM7FY8buM0quD5oZs0Ng1aJdoYzdApDkz71QoclVsAZAlMkhbtHtzVsZpCLd6s0HFHGS8QFXK5s",
+	"/7KxgRDk+qP+q3Z/VFjxM0qVx+ldMR3952uIM+9nOLpQ9w01GYpDzFcZXBt5VtezEUmHUKAwDX5YIJ1s",
+	"YLc+Iz4k1ZrlSHX/KC1nCPXDIw5sgO8I/itHgc22k4mXxRzbvFkGFYeUCEQUjlYMU4bFuueX56b5kVxJ",
+	"Kzzug0QpTx4BizqLqh/skomRBbwWeKlIIJKtJbC3DvI0V/qVWGAOvI8ryWHF9vHsZRflKk3U4b9YwxAp",
+	"H93wkDPT2pB3CIA0Rzt0XtyVJkySZxmcZig6ECxHAcznzQScrQvS1WkRKrHuFosF1uRweH7GwSqDQq4y",
+	"2IAkvSQ8n+qsN8rcK7653SnDc5wW/qLYx0kIkeWobbMYm5l2VkrSWXdWnA4iiveI8aBaYvqW6NF5QSgt",
+	"xrkxX/1A0b7SGT2N8JsXlm/pLdHye6eYzoZSeuQoUjNZMTpniPPN+2wkDjOmv6ZdZOjg8H64ncQ+0BlN",
+	"Jg9NLZ9rYh6WWvRxVLbsPJbK9Kr104HVJCumgMXBvXRflVJkkZhAuW7eooGNt5PJ+Y78Z7zzenK++c2V",
+	"YTu2VofBhkk6OwC7m3fXjTG6QcMgRxRKqwmFGBVS2t9ajfXxYoHaBqOZyfykN1ilqjp41Wcc4OUSpRgK",
+	"pJyg/Vjq0dT4GrradXo8J1DkLICeV6WEXOBaWvnhMKMyifCcoNQQJw9yMZ4TTOatxz+akhntiQTZR2ns",
+	"h+ntbxA99tijwjhQYJGnKOgszSiZN72tQmD78b8KQTNKJ3A+IjMacN7kYkEZ/h/N65hoklJ8TxmABIyG",
+	"QMB5jfnR5xVm6zD1D1WWqFW7dAdAfaDWL0i1nXv9CkqJrGYSWF310g4lIZ8zmq9UwrGbXcVvs9tj0Kb9",
+	"oYy12q7guTZeZTS5Vn8dKQRoYa9yYSLlgDcb9uTzg4S9JLasBNURESwQeBgr9y9A8i0wmpCk5KyMK5Dh",
+	"gEcJh7E/WVTthDKaA3aHR49tmmJBuHXFdaKosuiqH1qOMRc93GwJJQJiorVtndGaIXEHVMmHjUqMSpK1",
+	"cSmj0BC3XXUsSY9YSBacdshzy+BaqZWlgSRxYFQK+rUtUhPtdYWofBQ1wty4qsfF13dfT41eCYCn8z6Z",
+	"BWzBUxM6wnrYoKrLuT2rOluYplJJDu5IiTHN6y8oZSkm9mhCG434+6H6MrfiKdCrencl9+pgA2kh9jc2",
+	"ldX6tVHWO7uTGIdYn43oGpN5PdR4fHb65urkbHJ28WHwXyqCdPHn6PTN1ZvBxeDNkffg+GwSxdHZ6dXw",
+	"YvT+SDc+O70aTy6OVID13enw6OLNxdm706H9+GO/HVKsrxpisCsqbQqH1I7OKhRoqcPQQrF+ldUqk4QH",
+	"UZhs53dwzGd0HvTIm+QHdaphM2CizIPqF+LCGa0t2rtuqVR3bd9KzSKjc09C9lPBaZb2HFK3fIQhGVpS",
+	"gY572GgKtY8QmKhlwZQACJFARueT8GHF9UoZA3LiggJrbHkqlucYP6ZSERib82Dy18cgPhRJjZpdnqaF",
+	"0iIpEAwm19rVJqEogmxNtuCvE4+pGTp6lXwcqrVrYusuv5bEZ3uE4nt5m1qI4qKgBsg5TbA6FaTOvimi",
+	"cJAHo1l3nn8wLKHdQcEQRa4s1FcwtZGFcoqbOcmrdvpzxJaYS/VhiAh+oFep4r0PuYPti7rKZP3YphGg",
+	"DLy7GPXx8hTpSD2c7K9VY+tlzyCZ5yYuUUnCMm+A3LzABtqeb8fgH4j8Q/7L5b8p+kfFpf5PxTrOuumR",
+	"MKvQ4WbQglMP7BqoJxXM6d4OLsm/gU+D8eFo9AlsgfMMSosOfRbq+dvJybF8fIGThXpqvhKYzFWDdxfq",
+	"s3cXx1LgmRgI2MBLOEcxuEXTFZyjTXWMzSk5cqwojmTfkh4vRkFhG4rU1N0EZkBLFTYMoWd1KmHNDtdJ",
+	"htQkqHBnT6lKDDSfcdV6RF4zSoRsOV7QWzBFM8qQbsmlQGRU6wsaY9ktXHP3hf4JbjDH0wzFYIHnC8n6",
+	"FqASBjy4lCmveoniyOuzDSVFAKguHkz6tD6Wrx0olZjVFBWhKo0m+5Gcx1CHh2Ai8I1x46rukGJ+1fw1",
+	"zDOBUtlaxcWsFrWAHEACEGOUaYSmGu+qlSkakCEwzYXyUGICco40FRH32n1Ac5XdyBG7wQkq4c8CHMWR",
+	"AUai0Ui9oqsGHNqs6pCtY84/L2Ujm7kNhV/oxGlVdzvvWCoFYVOOGLLy+aG1HcJ7iEobT5smaw1308xM",
+	"t6/F7h1eHPvjBMJxollnrW3EGvMFYvrtwR1R0IkX5xwNVXBHmhU6GOZ9u9npsPVXv4TesEx2KGp2L5zD",
+	"ubJ1Uu1KqBBfwKVgDr5UZLs5VUw8bVElkEutLWfEz7UohduLE6jNBOIBBBhKKEvvQSUhwqCzGUeiXefV",
+	"s+DXeLVqmISgIqTKTuRjDyFLKJKFlGXFFDqU1mXpfK4exh7bccB3LPy4nQeBTqUt86CUjLDGCQEd6XPQ",
+	"7FUfANPAqiQajm19+AgnMfB4YvsVmmMSDG4WOlMlhKrgNOmZGxfwVuphYxVlGUIBg301x/qsgaeJDfKc",
+	"oaXUUDYOodpMj97HYEQyJGJwlgv1/yuarhuyQOX3kKTNFmFpCI2eI4LYfL09UNve9mgpNeDtCzTHXCAW",
+	"g3N6i1j5bXDw1QIGeVw+tsOmYON4LwbH+zE4fhaD0xgc723Jf/fVv8+29BP1fn9LNjl+tnW8FxwvJyFh",
+	"8I5gUZvnh0UMruU/N5DJP/V/H+TDGLwfxOBa/nMDmX4Xg0EM3sfgzxgcoozjnMfgNVwwRBYIixicI5Yg",
+	"EsZCwymKEzt/TeQbJF8ihhMAuUn67Ra/N42y1hkrffJfKStVTQHUflyXt+5Vi9FfTSaWVr/1Ervva8Ze",
+	"d4RoRLDAMAv1YTWhosiJixf1S23VtM0aGHKoEq51zgs2UCThGkuyydnh+Qgwr0ewYjTR3r4yOruLuFhF",
+	"oNSdsbFVcFu/1IY15mAJ2TVKJRF9ujh6MxpPji6Ohp90aSTZVNBrRFwhHagrKwFBL8m0iNzCREIr3wJE",
+	"0hXFRHAAbyhO7ToSZIpStM63HcBL8un86HQ4On0Tho+SbF0G0gImG37aockK75hQAf8U2yf72/ufVCGS",
+	"4vdOwpAiSpjxT5fEzWm7pEYbYKI4KjAXLoMjYQwvmgbfK/uU0OUyJ6pSBJlbXwcC6GR8DjYOL46GR6eT",
+	"0eB4fDU5+/Po9GqgMqO66mPlLAsPL+1OQzBqBIsdt4xqRWwuhM7ZGp+MNb5hIuSy6Bo3JC0CL64XS3d1",
+	"P2aHmqgQ9jHId9KgaYmnFae6XEMeOn1ZvOwbxfCGdkKyxzHEYqCO+fQqvceQtEuhV/bFG+JuJpUuE+SZ",
+	"VcrLKztD/UKcbfkHo/EZ+OfL3T3Pi+6yETyIu1ISwmHrrvC3YqTbhfK51M9VSDu7mKqPyx5h89YUCBdB",
+	"0K2ADZB3deoh5A7b5EIdx/QX/yFFIErLGbvYfhm0Tgpu0R3ckpvd72HE2o9CNbukA3F/Ar2F3HBd/xMN",
+	"Pw1jOIQ6UgofKrgX1f84Mu92/1d1Jb/7QAZR4SU7S5J8hesnpgqnWRwdQpKgLCtlHH3sDtX5yIn78GZL",
+	"iEDym/A2lDKnidaAn4REbTYrxCSq/brAdCZN97flg5B3LUg6RqJS36YR0q4SG+3BuoRXxrlrXaAOiRno",
+	"v2G+5SMojdPteXyjcqCl7ndpPkDQFBd8O5mcN0UClUc6LFrUK0+i36PqJPBfPCAqNgkr2QNSyQDSumVt",
+	"84HJAp2YzIyqGZnacqILKFQhPSU4lOYuv5OKOubW7PAlyPGHwX+NpXF5fHz24WhY/HV19vr18ej0SB2E",
+	"fn90Ea6URIm0hUXLfqjeK58sOhmMhpuBOKm1MTZ03KZe+dHUW6RM5eebkpPRQbTxr8HW/4Nb//Pxy/7X",
+	"zY2t/9gsHjwrP9jd+uPjlz/qzzb/I4obk4sOg8jW81INdEjQK+st8SytlIpG1RENjCOVhxpGIuYApzpR",
+	"lStNMF9lxeoqPXEJrxEQtxRQBpaUIfvqlrJraf5QgjpP/Nh63gHiMvOSywHJOgZLyl3ZFaUi1OqJmqZg",
+	"xaSoS20x3IvXoyFIIEtjFR0iSFq+kOFs7cy78KESHYBtXo4VQzPEGEqBbWvtVZvMDTmQas3LZ39s7RWN",
+	"TDrSnZaqSDpooPnUVqzXXmilnqnkA511kIINPCeUabRovW1Hv+p/mEylTDUxnXopiaaTMJ+VZvuspTxu",
+	"wC3gCxlfogyv3p4dXr0bH11IYXJ+bv88m7xV/0sqCAqT4DktOVSu1S4tJHDag5Z15nSAlM2pONWTTa8O",
+	"FInBPG8usa9KyqoWOwzBVFeWVW13rGaYWJ+Ro39ICvLvUUCrkD/FYse2zLA+R+bJXse8duaxt1sEd6Ii",
+	"NDBUO2PIQSjUsaPSEUI/81/X0JWE1RrO6qf1uwMW7tyLN2w4CCAQc0XKqm7oIpqFCfiwAFCYniXBhjqu",
+	"RszGgq56doxIWukWbJA8ywCemSD75j0ic1lWDlFrYYLS4nRnFUWPEK1rOWDfZhT6U1ddoPTBh7TL1SHK",
+	"M7WiRmNXsYJOvE8bivU0nd7vPym6WknJXV/XntFrKXAm/WSp4oX7hMArQJfOWnQV8/V7Lplvhh5KDOed",
+	"YfWJuEPQtDtDPRC41gtXOmwezrp/zBD5d41Rl+bpAtb6SFkm1Fr5JqSqndRajLe/d9hbi3G+XMIehy9K",
+	"49wpQB4YrM7j+kUtSeP3HtJ3D/ktsL+VwH5ysjbEZO9IRpNrl3jW10dVwenQq3donK3SelJ9P7RMcxxp",
+	"W8kdxrrDCfM7HTrsPIhF0G31ENbGMucCTBGYKyuMAbGAxJ7Y2nzkQ3Shs3Mq/pumOy4f/aEn6bqOL+mB",
+	"2k9TGOxvvM6z7N/NvS32ViuJ5RgM8WyGmA4+/7uteWCzJ83UNj22lz2p6w+Kz7p9s+Vzfx7gISJ7b+7u",
+	"4LVSwS0V7kRx5Uepgm/DKSHbmIdypcwr03FzIVR3k0hDupjOunK9BDxThhwCNYLaC6+0p6yGBJhH5bgp",
+	"TbX1u1BWir1cJQRM9aKXEAJIsCLVYekumU4ZrBqF6MiucR2PzXC/r94b0x/s9/7FNPeFuiaPLYV404mr",
+	"hHfnasUF9ffiv34VCsdIFKzTynytxagdG/etSO2QMe5VW7rSf9/qhIfeStjqhMWC+OdwBhYec4KqUpf6",
+	"490EgaW1R+eBB3V8RzIdf4Oq2o7WmumzIMdaNe2elNqyTVhb1zVxARDMArn5VUH+W/L/lvwNUDsB0jKS",
+	"Y61WIlMzEe2F1oub0jhwX4T86Mtc2BtW+3Voaj9pOevHKS8QTM90TfcPDAtk/paP1e+gjFxJ9ZGHDxoG",
+	"hzcfcAATRrmUAVIO87sUkn9fUimjXpm6HSXag4KyvvKPuqV/VQyrS6+oqhiJrvK+VLGCaAnRDdoSCC7/",
+	"j1jQfL4Qt5Rd8+2ELiNL8tEJPHqPgGxUv1JDnUImMAOD85G+flIgFSh2IWH99eH4ZBwD9Nm01peAunPo",
+	"OdeZutvKJ5UgI9LN+IMVTBZIyml9RElkBVTqWsc4smU9DqLd7V3djq4QgSscHUTP1CMVb14o7tipXIa5",
+	"oiEbQ5++VbHa2pWlwFzwKYfXlwWqXFVJ9nIuonw7qDIPc7GQglZfeBrIFcy5CsHkIoeZvi3VOkTkjyLv",
+	"XV0YoOvh0dnMVFaTAwD599YUZlKCMZ0/XMqJNzMq32xn8mZf0XRdOdALV6vMBMB2/ptrc1ybrp2pLd4I",
+	"X8vUKs1ZnZ+lNmW1HPu7e4H9wCTCKYoztzY/EnhGJVGQVfPC0OeV0v50uoliNW7dngZ/kiBKE4xLBLXz",
+	"pXIl9lc9uQwFi2ep501EtoBC5ZBOESKuUoNPe4ZqYOXS49Kdx5fEqL/DowswXQvEQ7ShASnTxgoyqFxY",
+	"XN0ihiXAkokK0VCZalRd6thbkvbM8a8fa1TxPODKp/ZMtCSM57rJNyaKUyrAjObkadGiXq8qLcbRPBQB",
+	"Oab0Ol/9eCLTcDwpItv9dlKv+UJ/m8X2N6fhgixr8pTvfEn4KP3avD3bI39SdhJ0G7yhm6+5QEtzhITz",
+	"fGnIvb79XhLJAoQKsEZCs4I6iiK1CpSqMzuqF+1FDWzfmKg92BS01Yf6LwmnAAujDSPiLiJCqd7dsVDH",
+	"WeQUpIIqx3dJJyH+sXMu3QJc56FAnlsFWN/mC3Ecdze+1dhq/58NbPUN9Ah/moNcLH4pbcIuZpB+K2yw",
+	"I9VHCUlQvF+oqLhO37MH/iySwHRdCPI5FOgWrlX9D0kuS0wQWNDbPgpqszivrdITIchvJefDVBmo7uHd",
+	"u52LhfNEfT+xb7yVNdp6UlxQ0K5Hgv7pnSor6PMPzh0R3h60A5uXT/bqe0UaiqsDyorol3O6bV+SdyYf",
+	"QcBrBCRbrdQ57XLVE3WCZAml/UvUpfPq5zWSMr4oqALnEEvJbjzGHEypWBS3ysttpvBJhnYAPa2Bj4Jf",
+	"WfxX5mrjgb22gf1A8Na4+cEW8KmoiDfoqCLPp0ssntp+cWiuLK1IFp8UKpyickd3kgxB1qZHqUnzkFIj",
+	"KFBfAyx4MISvRtgGl0RH5j+LynuLUaU7/ZUjtvbcJvdnAglTKXB+KOF4kvtOOxUq/BkcP3HqUzAGVh9Q",
+	"0qG7JNVK7WFXSAchptbgLWS0Z1G5hVQKjyRXaZWq28i0BOeapmpuDn0+d0lv6l67htvSWrwnvmbQauX+",
+	"MiK6bJoPoYB3l9GPAkm9qkiAxm3aCDQcGGvBZEjLX3u/6Ei2fvKenyZabWFF3mhO/N8cMXuNTvV2EMq8",
+	"m2T83rZBwWRvkHCXmngUMkr5JfHqu5Ym4NhVl6bweraJXKVLbMxJpG7ObICFPwGejBuPN+sUYinJSp46",
+	"nVSgRlZ7adBFZlIPCihs6O39/psLSkVZLp2c1Z/J3bn+9P3+G+/B4QJiiewTSPIZTETOEKt+87H3/vjD",
+	"JYBWTaqq1dOVAW+QaODDZkkQOwWwzCGGPZo2L/438S9ZNPgz77WH7QbqFPz5pKjFTK1MJ0EJWtsvzKHz",
+	"rZU5pV7sGTUxWzug3su3rymh2aEfEJpBAVg6Le8RVmvh64a+yhM5z9mK8rBMnXy2x/fjaPJ5qBe8eKQJ",
+	"7JxiIk6ga/ox7jsrLmByfYxuUNZ/Ut/c9VVgRmVIB8jR5ke5mrQrSxK/PV9lGR7EUNhOHyPBrc/K+0KX",
+	"yAs4rhpVJOXOUldtLSErQIhV/gDQ+QPqtzTE0zWBS5yAFcPyYUjDqtfY+Dac/402geYSIY/gZaqtljXy",
+	"/8pRri383/xg+GEc4Ieu/Wjni/nDhAoL30LAY/RdqDQOduOgbA9e32ez+r3xNW58HbypPFq/GbOn66+T",
+	"NeWIHAu0ZW/BbFUWbeuxbfzjtMXHZcg0d1dxFB25tXz2cte/+GXv7sx5AQV6R9Sx3UD/0cBLtv0QxdGg",
+	"nxn+iDpibWVD4VHbyF2Z+pvjqqphAEVVjtPZJK4ycFNygPK2GX+eqUpX+jYYDdVJXy4qo3jW+2b7klh3",
+	"Vbb2HFa+IuqNcI3WvME9V3Y8lOb0zTwPvRLIevnsDulyCbdMYSvvaoD69CtXW4V4/Bqto04V+JvxrQdw",
+	"mwut1PB3UkOraVcQZpkeNixfbeoqUCJZNKcwlD81R1wp6WRZ/X2Va23Cxf7uPnDakC7UgdjWNVrbY3fb",
+	"YEyX9gwHB0u4tklFAJoTFc0ZCj8VU38r96I/7fKB5u8cHAtC0szhvpJcoj2TJ6HrzIvfanKP/Ixmvi9v",
+	"5ikUcEvVlJihlmyNsUoXvUEkpWzL7bUqbqbyT0NZsDaqtoRC+XQ4WkIicMIvibqPXt0g4BIFdd8PyM6Q",
+	"IA6hgBM7mV82fuDP8gdxdhmEXiyticV888SzTiQtVQAWtCNmkRZ3hTbz0ciIMA4g8D5w13XaIJphMZSG",
+	"L6KVnLyts58q71VYMaFZhhJRGkEykBlFLNDSHrRwFx/Yu3fC+d9qsUqbq3c16t9na/Um/YjeWn+Z3LUg",
+	"T2evq+TNavh8mAMXJrcwx05RAaozq9yajQFWMQm19sKVJobpY/x5qzp29aGfIkF/IxOsPv8AdXiNLO6f",
+	"jg1Ws4IaCaZOmKrQ+JZXl7xNA4LurkxBS/dkhsNegCcMIZXifXw0tK39RGx7+2ds3S0qBKaO8WxNIUep",
+	"/UjHxZZ5JvAqq17RyrcvSaEdqWuCGkJmlcLqv6yO1FiR/hHktSWBp+W7B/a6T1eljEr1ypSIeXIht7Ry",
+	"L29nOm+FU3e+mD9qIbjqdrKkN0rfcmaLHbIhZclj0x48paIUT46r4raLsb2alzbTPjyqw/C3job95qQH",
+	"xciqvNRLIStxU5s65qXHOy+zS431jpZWoOAtiexhF766kJoytyf2Y8A3VUn/JHNsX+tpOtxM197V2cJU",
+	"bwxHpEU5FN7javri+u9+kFiEN8Dgvb4TGKWL2e8uGuZI/BYMDwkFhBmyXS7MMFveQobuY6XZb20J0J4m",
+	"WnxJirsAbF8Gw7E72W5RvoFnAJL1Zmw8GmqkFaNzhnivUN9rA+W3NvWehGlXmWyAjmyLp2fUPTFuClN3",
+	"I/+Ymry9PIHVro0t2ejTqDjJGZrnGWSXRHnZ1RXb1S65dsmHnIUpvSW6vhBJbXK/KSivu7gkbiPv5S3U",
+	"FZuDPPfr2pt2hnryj2hsVmmj5Bh8MgwyYXg+RyxEye37jTrdu5WZmtfdW40p/N5Y2Pu+DsHjcB3uX3t3",
+	"CE+6LZ5z3IT2p7JtSBWNUEMeiqye2j7SWJK+MQVfyxTeWtC+c8+oFn+Y5VkGTHl2VVdCpd17JdbdztEo",
+	"4p82zzy+jG+4iuARhHxxf//vPOBA+UO1lTTzTdOOsnNTXOjQ24ip3PFgyss1DX5JuLB38fU+GOwoqLif",
+	"4JffZbzpdu8vSqDZhfi9szx0Z7GorHPKvGeqQkbnd01R0E47Re3zzb5JBccSor9NNsExnT/iHiLX6GfJ",
+	"HqjSU5eNML9X1oA3yiNmCxzT+ZPNEmhy9voJ8pZGRsMGd69pUNlAvuuB3wLHwT1i/hNkINSIr0rVim62",
+	"btwFnh2nKBZYahpYSvjSxZ4biCA2V4EYni/VdzFY0VvEYnBDMwHnKAZIJNub4JIwpF3VNumy0a+kozKq",
+	"/C5JvasUGxjkxLvG8ekGX6Zr75hyI/nf92Rj05D+PW+Ng1ZvdWs9WtbI4vriQrxEYMPedLfZHFdy18UV",
+	"g/W53K4NAkTSnuMjkj7S6M23duqDLzkjDTDYaygD59n21HE53bP61eP0XNftn4KqC0DBRsFOTdgxF2MG",
+	"QfMh+d6FGDw+b9PiT8o3D2sRlgKeJwnifJZnuqzNbwvX2y9KQr2HUsSQC723JK3lcjKI60q/pSMBqiC1",
+	"uQdjioCadVF/vZ7PjznAqlL1JVHFRk2x9inS96ZCaSbM5V4Es6p8dxWt9WXfyQISzJcxwEJ2aXu7JDNV",
+	"PQJpCWLP/7iCwvbiasQFJvNtMJgJlUdemlYcrLGt4hxTZE4PSUrUs6xjJYHE1FudzVAiAJ6pkAjL1doJ",
+	"GjZk3Er8HQtkj5GQC/LLVC3ylrNHpSKGOGI37ihsQ1FgVQacq/NrrvndK6g0RfCmqEykZhRUuZT1BkOd",
+	"vXChX5/S22BCmwL2wpvX38Yg9yb9iIa5v+YNBvrudyD7VzC1w//efP0UOkXvAHqc4jN1M7/vfPF+dGSh",
+	"HkKSoIwDSMxV0iWqeDDDJ6p71Ynfr+N4PbxH3kHGrzb6GRwck8qUuwAoLVkrJJ2XN9+j6rJEcNYqCX6s",
+	"f7tE+E+JRzV9w56c2exPOVbX8/lN+/gEX62BQYUxKHmAi3ljhqoJqhfQ/VSOQ5+7jNttw2DjwLsXvyl5",
+	"VflJQxVj3GX+tdv90eeVmkQcwSz73nVkvIXqqjNYorjfW6p3wZLJCPGwU+dV4evLVYuKV5zuP1VpPwX+",
+	"QxVI1YnbJWzdYE9drEbrbmCGSxrei3A7cxWmMgFYgwVkBq1KIb1slbX0XJc7X0p+zK893Nr6shWUAkz0",
+	"hqsqIE9pLnzbyPehulzhSwKzsjO8wTs9Kb4emrtdfhLNpjTvDgCqLuRekDx7+X2la20pQtLFa/T9r6zz",
+	"BydP8vq6N0iUCKPhviKvSZc+5Dft1Id00R5arhmv2NGc4cl5DFTGDoNkjuIeESQJxcQH96dSkPy1qCtI",
+	"WXY/7SjLQqqRzX9tUY56BEhK6+2iJB7UL3ZjsISfD8De7u7m3aMnLyrBk/vHTqqQqgCKpNCCoDywd79F",
+	"PKVp5UugqXCauhtZ2VFQ+abFAnPNCRuj8VlnNG5YPen1oGhcG3hTNKPKu9kXPl1a5x7Qfae9pEtTL8nC",
+	"35p6RVOviX/Y4fQWOtu/WYE3xwH+juEQM/WfORpSWe2cZDS53nLu0eZlf6daHrqGP5PRVoH9oeab7u7H",
+	"2m+CAr12Jed2oIJjlb9vIMNwmvXKS3JtddC6rTikSwl9b79pOgru1kcqjzuUuVGApJo+WXpuiJ9Llywm",
+	"rsZqylAyje6bKFTCZsMgts0PKwzrVrAt08Q1+n1utWdB2IJfvTzttnKw6gIQRzH9ysBqTh+XOb29Aqwb",
+	"wZaBbbny42dg8m+0Tbkp/9DCrjUoelWAdEv8u55rn/tIunlW7tr2JPbOF/uXcbw2Xburb3/XpzoSz6Pj",
+	"LsgNpjjpr47NF334zfXexWkF3E26/Mvn3/FMRmJVol/vyv/mRde0xEy7XuRDpKgfgRVkYl2hIDBEtmyH",
+	"TW0oZdm5MgL2C5XWcEkQFgvEnFxQ8V45HqtArMc0fkoLQJaBW4iLA+D6uaBFd5ekqcMuuj+XfUXfKlpU",
+	"QPSrUl0zrWjCE/QakQ4ntSpLIdtxnbuaQOKyTwV1x96QU0yaHM2qjwbbtNtveJ+7Wequ0jt4Rx+qY2OB",
+	"lrzTl6YW4KsbHjIG160eNY3FJ+fLKp9+LKBsT8ykzJ52B1B/dH8aGyNNYt9IXJiV+oXkhIbJFMxRGXL1",
+	"NfTExM4X9d873BJfPqb0Ol89fC11P3Y5u51ZFrInG34tiKeipddR/v1Dr6dPMtxqaamJLmVj5YtrU4Qz",
+	"kKIblNGVKrWh20dxlLMsOogWQqwOdnThggXl4uCP53u7O3CFd252o68fv/7/AAAA//8w/dLjjRABAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/manager/api/render.go
+++ b/manager/api/render.go
@@ -127,3 +127,15 @@ func (c CertificateHashDataRequest) Bind(_ *http.Request) error {
 func (o OperationResponse) Render(_ http.ResponseWriter, _ *http.Request) error {
 	return nil
 }
+
+func (t TransactionList) Render(_ http.ResponseWriter, _ *http.Request) error {
+	return nil
+}
+
+func (t TransactionDetail) Render(_ http.ResponseWriter, _ *http.Request) error {
+	return nil
+}
+
+func (s Status) Render(_ http.ResponseWriter, _ *http.Request) error {
+	return nil
+}

--- a/manager/api/server.go
+++ b/manager/api/server.go
@@ -1489,3 +1489,188 @@ func (s *Server) GetDisplayMessages(w http.ResponseWriter, r *http.Request, csId
 
 	w.WriteHeader(http.StatusAccepted)
 }
+
+func (s *Server) ListTransactions(w http.ResponseWriter, r *http.Request, csId string, params ListTransactionsParams) {
+	status := "all"
+	if params.Status != nil {
+		status = string(*params.Status)
+	}
+
+	limit := 50
+	if params.Limit != nil {
+		limit = *params.Limit
+	}
+
+	offset := 0
+	if params.Offset != nil {
+		offset = *params.Offset
+	}
+
+	var startDate, endDate *time.Time
+	if params.StartDate != nil {
+		parsed := time.Time(*params.StartDate)
+		startDate = &parsed
+	}
+	if params.EndDate != nil {
+		parsed := time.Time(*params.EndDate)
+		endDate = &parsed
+	}
+
+	transactions, total, err := s.store.ListTransactionsForChargeStation(
+		r.Context(), csId, status, startDate, endDate, limit, offset,
+	)
+	if err != nil {
+		_ = render.Render(w, r, ErrInternalError(err))
+		return
+	}
+
+	response := &TransactionList{
+		Transactions: make([]TransactionSummary, 0, len(transactions)),
+		Total:        total,
+		Limit:        limit,
+		Offset:       offset,
+	}
+
+	for _, txn := range transactions {
+		startTime, _ := time.Parse(time.RFC3339, txn.MeterValues[0].Timestamp)
+
+		var stopTime *time.Time
+		var meterStop *int
+		txnStatus := TransactionSummaryStatusActive
+
+		if txn.EndedSeqNo > 0 {
+			txnStatus = TransactionSummaryStatusCompleted
+			if len(txn.MeterValues) > 0 {
+				stopTimeValue, _ := time.Parse(time.RFC3339, txn.MeterValues[len(txn.MeterValues)-1].Timestamp)
+				stopTime = &stopTimeValue
+
+				for _, sv := range txn.MeterValues[len(txn.MeterValues)-1].SampledValues {
+					if sv.Measurand != nil && *sv.Measurand == "Energy.Active.Import.Register" {
+						meterStopValue := int(sv.Value)
+						meterStop = &meterStopValue
+						break
+					}
+				}
+			}
+		}
+
+		meterStart := 0
+		if len(txn.MeterValues) > 0 {
+			for _, sv := range txn.MeterValues[0].SampledValues {
+				if sv.Measurand != nil && *sv.Measurand == "Energy.Active.Import.Register" {
+					meterStart = int(sv.Value)
+					break
+				}
+			}
+		}
+
+		summary := TransactionSummary{
+			TransactionId: txn.TransactionId,
+			IdTag:         txn.IdToken,
+			StartTime:     startTime,
+			StopTime:      stopTime,
+			MeterStart:    meterStart,
+			MeterStop:     meterStop,
+			Status:        txnStatus,
+		}
+		response.Transactions = append(response.Transactions, summary)
+	}
+
+	_ = render.Render(w, r, response)
+}
+
+func (s *Server) GetTransactionDetails(w http.ResponseWriter, r *http.Request, csId string, transactionId string) {
+	txn, err := s.store.FindTransaction(r.Context(), csId, transactionId)
+	if err != nil {
+		_ = render.Render(w, r, ErrInternalError(err))
+		return
+	}
+
+	if txn == nil {
+		w.WriteHeader(http.StatusNotFound)
+		errMsg := "Transaction not found"
+		_ = render.Render(w, r, &Status{
+			Status: "error",
+			Error:  &errMsg,
+		})
+		return
+	}
+
+	var startTime, stopTime *time.Time
+	if len(txn.MeterValues) > 0 {
+		startTimeValue, _ := time.Parse(time.RFC3339, txn.MeterValues[0].Timestamp)
+		startTime = &startTimeValue
+
+		if txn.EndedSeqNo > 0 && len(txn.MeterValues) > 0 {
+			stopTimeValue, _ := time.Parse(time.RFC3339, txn.MeterValues[len(txn.MeterValues)-1].Timestamp)
+			stopTime = &stopTimeValue
+		}
+	}
+
+	meterStart := 0
+	var meterStop *int
+	if len(txn.MeterValues) > 0 {
+		for _, sv := range txn.MeterValues[0].SampledValues {
+			if sv.Measurand != nil && *sv.Measurand == "Energy.Active.Import.Register" {
+				meterStart = int(sv.Value)
+				break
+			}
+		}
+
+		if txn.EndedSeqNo > 0 {
+			for _, sv := range txn.MeterValues[len(txn.MeterValues)-1].SampledValues {
+				if sv.Measurand != nil && *sv.Measurand == "Energy.Active.Import.Register" {
+					meterStopValue := int(sv.Value)
+					meterStop = &meterStopValue
+					break
+				}
+			}
+		}
+	}
+
+	txnStatus := TransactionDetailStatusActive
+	if txn.EndedSeqNo > 0 {
+		txnStatus = TransactionDetailStatusCompleted
+	}
+
+	apiMeterValues := make([]MeterValue, 0, len(txn.MeterValues))
+	for _, mv := range txn.MeterValues {
+		timestamp, _ := time.Parse(time.RFC3339, mv.Timestamp)
+
+		sampledValues := make([]MeterValuesSampledValue, 0, len(mv.SampledValues))
+		for _, sv := range mv.SampledValues {
+			var unit *string
+			if sv.UnitOfMeasure != nil {
+				unit = &sv.UnitOfMeasure.Unit
+			}
+			apiSV := MeterValuesSampledValue{
+				Value:     fmt.Sprintf("%g", sv.Value),
+				Context:   sv.Context,
+				Measurand: sv.Measurand,
+				Phase:     sv.Phase,
+				Location:  sv.Location,
+				Unit:      unit,
+			}
+			sampledValues = append(sampledValues, apiSV)
+		}
+
+		apiMeterValues = append(apiMeterValues, MeterValue{
+			Timestamp:    timestamp,
+			SampledValue: sampledValues,
+		})
+	}
+
+	response := &TransactionDetail{
+		TransactionId: txn.TransactionId,
+		IdTag:         txn.IdToken,
+		TokenType:     &txn.TokenType,
+		StartTime:     *startTime,
+		StopTime:      stopTime,
+		MeterStart:    meterStart,
+		MeterStop:     meterStop,
+		Status:        txnStatus,
+		MeterValues:   apiMeterValues,
+	}
+
+	_ = render.Render(w, r, response)
+}

--- a/manager/store/postgres/querier.go
+++ b/manager/store/postgres/querier.go
@@ -13,6 +13,7 @@ type Querier interface {
 	AddMeterValues(ctx context.Context, arg AddMeterValuesParams) error
 	CancelReservation(ctx context.Context, reservationID int32) error
 	CountMeterValues(ctx context.Context, arg CountMeterValuesParams) (int64, error)
+	CountTransactionsFiltered(ctx context.Context, arg CountTransactionsFilteredParams) (int64, error)
 	CreateOrUpdateDisplayMessage(ctx context.Context, arg CreateOrUpdateDisplayMessageParams) error
 	CreateReservation(ctx context.Context, arg CreateReservationParams) error
 	CreateToken(ctx context.Context, arg CreateTokenParams) (Token, error)
@@ -110,6 +111,7 @@ type Querier interface {
 	ListOcpiPartiesForRole(ctx context.Context, role string) ([]OcpiParty, error)
 	ListTokens(ctx context.Context, arg ListTokensParams) ([]Token, error)
 	ListTransactions(ctx context.Context) ([]Transaction, error)
+	ListTransactionsFiltered(ctx context.Context, arg ListTransactionsFilteredParams) ([]Transaction, error)
 	LookupChargeStationCertificateDeletion(ctx context.Context, chargeStationID string) (ChargeStationCertificateDeletion, error)
 	LookupChargeStationCertificateQuery(ctx context.Context, chargeStationID string) (ChargeStationCertificateQuery, error)
 	QueryMeterValues(ctx context.Context, arg QueryMeterValuesParams) ([]MeterValue, error)

--- a/manager/store/postgres/queries/transactions.sql
+++ b/manager/store/postgres/queries/transactions.sql
@@ -36,3 +36,25 @@ VALUES ($1, $2, $3);
 SELECT * FROM transaction_meter_values
 WHERE transaction_id = $1
 ORDER BY timestamp ASC;
+
+-- name: ListTransactionsFiltered :many
+SELECT * FROM transactions
+WHERE charge_station_id = $1
+    AND (sqlc.narg('status')::text IS NULL 
+        OR (sqlc.narg('status')::text = 'active' AND stop_timestamp IS NULL)
+        OR (sqlc.narg('status')::text = 'completed' AND stop_timestamp IS NOT NULL)
+        OR sqlc.narg('status')::text = 'all')
+    AND (sqlc.narg('start_date')::timestamp IS NULL OR start_timestamp >= sqlc.narg('start_date')::timestamp)
+    AND (sqlc.narg('end_date')::timestamp IS NULL OR start_timestamp <= sqlc.narg('end_date')::timestamp)
+ORDER BY start_timestamp DESC
+LIMIT $2 OFFSET $3;
+
+-- name: CountTransactionsFiltered :one
+SELECT COUNT(*) FROM transactions
+WHERE charge_station_id = $1
+    AND (sqlc.narg('status')::text IS NULL 
+        OR (sqlc.narg('status')::text = 'active' AND stop_timestamp IS NULL)
+        OR (sqlc.narg('status')::text = 'completed' AND stop_timestamp IS NOT NULL)
+        OR sqlc.narg('status')::text = 'all')
+    AND (sqlc.narg('start_date')::timestamp IS NULL OR start_timestamp >= sqlc.narg('start_date')::timestamp)
+    AND (sqlc.narg('end_date')::timestamp IS NULL OR start_timestamp <= sqlc.narg('end_date')::timestamp);

--- a/manager/store/transaction.go
+++ b/manager/store/transaction.go
@@ -2,7 +2,10 @@
 
 package store
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 type Transaction struct {
 	ChargeStationId   string       `firestore:"chargeStationId"`
@@ -46,4 +49,6 @@ type TransactionStore interface {
 	// UpdateTransactionCost stores the most recent running cost for a transaction as
 	// communicated by the CSMS via the CostUpdated message.
 	UpdateTransactionCost(ctx context.Context, chargeStationId, transactionId string, totalCost float64) error
+	// ListTransactionsForChargeStation retrieves transactions for a specific charge station with filtering and pagination
+	ListTransactionsForChargeStation(ctx context.Context, chargeStationId, status string, startDate, endDate *time.Time, limit, offset int) ([]*Transaction, int64, error)
 }


### PR DESCRIPTION
- Updated OpenAPI spec with GET /cs/{csId}/transactions and GET /cs/{csId}/transaction/{transactionId}
- Added filtering by status (active/completed/all), date range, and pagination
- Implemented PostgreSQL queries with ListTransactionsFiltered and CountTransactionsFiltered
- Implemented full store layer (PostgreSQL, inmemory, Firestore)
- Added API handlers in server.go with proper response formatting
- Regenerated api.gen.go with oapi-codegen
- Added Render methods for new response types
- All tests passing
